### PR TITLE
Add Digital Facsimile link to Bodl. Or. 793

### DIFF
--- a/collections/oxford university/MS_Bodl_Or_793.xml
+++ b/collections/oxford university/MS_Bodl_Or_793.xml
@@ -84,7 +84,7 @@
                   </adminInfo>
                   <surrogates>
                        <bibl type="digital-fascimile" subtype="full">
-                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/368d0391-3f85-43df-9b07-869638189692">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1d091ec9-33f8-42d9-a620-141dfc7b1816">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>
                   </surrogates>

--- a/collections/oxford university/MS_Bodl_Or_793.xml
+++ b/collections/oxford university/MS_Bodl_Or_793.xml
@@ -82,6 +82,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>oriental@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                  <surrogates>
+                       <bibl type="digital-fascimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/368d0391-3f85-43df-9b07-869638189692">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
This commit adds a digital surrogate link to Digital Bodleian for MS. Bodl. Or. 793.