### PR TITLE
New: Link to Digital Bodleian for MS Whinfield 4

### DIFF
--- a/collections/oxford university/MS_Whinfield_4.xml
+++ b/collections/oxford university/MS_Whinfield_4.xml
@@ -92,6 +92,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                  <surrogates>
+                       <bibl type="digital-fascimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ccce57a1-ae6f-45f4-8e21-8fea2cc803f6">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
This PR adds a link to a digitized copy of MS Whinfield 4 available on Digital Bodleian.