### PR TITLE
Fixed: Link to digitized versions

### DIFF
--- a/collections/oxford university/MS_Whinfield_33.xml
+++ b/collections/oxford university/MS_Whinfield_33.xml
@@ -55,9 +55,6 @@
                      <title xml:lang="fa" key="work_426">رباعيات عمر خيام</title>
                      <listBibl>
                         <bibl>BP 2548</bibl>
-                        <bibl type="ditised-version">
-                           <ref target="http://bodley30.bodley.ox.ac.uk:8180/luna/servlet/view/all/what/MS.+Whinfield+33?sort=Shelfmark%2csort_order">Digitsed version of MS. Whinfield 33</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
                      <note>In Edward Fitzgerald's own hand, copied from a copy of MS. Ouseley 140 (Ethé 525) made by <persName key="person_19752874" ref="http://viaf.org/viaf/19752874">Cowell, Edward B. (Edward Byles), 1826-1903</persName>
@@ -102,6 +99,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                  <surrogates>
+                       <bibl type="digital-fascimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/6b3da54c-5f21-4dda-af76-726fee02d9e5">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
This commit fixes the record for Bodleian MS Whinfield 33. It removes an older reference to a digitized copy, and adds a digital surrogate reference to digital bodleian.