### PR TITLE
Fix Birjandi authority

### DIFF
--- a/collections/cambridge university/Add_3589.xml
+++ b/collections/cambridge university/Add_3589.xml
@@ -43,10 +43,10 @@
                   <idno>Add. 3589</idno>
                </msIdentifier>
                <msContents>
-                  <summary>A commentary on <title xml:lang="ar-Latn-x-lc">Al-Tadhkirah fī ʻilm al-hayʼah</title> (<title xml:lang="ar">التذكرة في علم الهيئة</title>) of <persName xml:lang="ar-Latn-x-lc" key="person_f4269">Ṭūsī, Naṣīr al-Dīn Muḥammad ibn Muḥammad, 1201-1274</persName> (<persName xml:lang="ar" key="person_f5056">الطوسي، مصير الدين محمد بن محمد</persName>)</summary>
+                  <summary>A commentary on <title xml:lang="ar-Latn-x-lc">Al-Tadhkirah fī ʻilm al-hayʼah</title> (<title xml:lang="ar">التذكرة في علم الهيئة</title>) of <persName xml:lang="ar-Latn-x-lc" key="person_f4269">Ṭūsī, Naṣīr al-Dīn Muḥammad ibn Muḥammad, 1201-1274</persName> (<persName xml:lang="ar" key="person_f5056">الطوسي، مصير الدين محمد بن محمد</persName>)</summary>
                   <msItem xml:id="Add_3589-item1">
-                     <author key="person_f703">
-                        <persName xml:lang="ar-Latn-x-lc" type="standard">Birjandī, ʻAbd al-ʻAlī ibn Muḥammad ibn Ḥusayn, 16th cent.</persName>
+                     <author key="person_7603024" ref="http://www.viaf.org/viaf/7603024/">
+                        <persName xml:lang="ar-Latn-x-lc" type="standard">Birjandī, ʻAbd al-ʻAlī ibn Muḥammad ibn Ḥusayn, <date calendar="#Gregorian" notBefore="1500" notAfter="1600">16th cent.</date></persName>
                         <persName xml:lang="ar">البرجندي، عبد العلي بن محمد بن حسين</persName>
                      </author>
                      <title xml:lang="ar-Latn-x-lc" key="work_1948">Sharḥ mukhtaṣar al-hayʼah li-al-Birjandī</title>

--- a/collections/royal asiatic society of great britain and ireland/RAS_Arabic_70.xml
+++ b/collections/royal asiatic society of great britain and ireland/RAS_Arabic_70.xml
@@ -48,20 +48,20 @@
                   </summary>
                   <msItem xml:id="RAS_Arabic_70-item1" n="a">
                      <author key="person_73701246" ref="http://viaf.org/viaf/73701246/">
-                        <persName xml:lang="fa-Latn-x-lc" type="standard">Qāḍīʹzādah, Mūsá ibn Muḥammad, d. ca. 1436</persName>
+                        <persName xml:lang="fa-Latn-x-lc" type="standard">Qāḍīʹzādah, Mūsá ibn Muḥammad, d. ca. 1436</persName>
                         <persName xml:lang="fa">قاضی زاده، موسى بن محمود</persName>
                      </author>
                      <title xml:lang="fa-Latn-x-lc" key="work_9703">Sharḥ al-mulakhkhaṣ fī al-hayʼah lil-Jighmīnī</title>
                      <title xml:lang="fa" key="work_9703">شرح الملخص في الهيئة للشاغمينی</title>
                      <incipit xml:lang="ar">الحمد لله الذي جعل الشمس ضياء والقمر نورا وبسط على بسط البسيط ظلا</incipit>
                      <explicit xml:lang="ar" defective="true"/>
-                     <note>Commentary on <title>al-Mulakhkhaṣ fī al-hayʼah</title> of <persName key="person_24458289" ref="http://www.viaf.org/viaf/24458289/" type="standard" xml:lang="ar-Latn-x-lc">Jighmīnī, Maḥmūd ibn Muḥammad, d. 1221?</persName>
+                     <note>Commentary on <title>al-Mulakhkhaṣ fī al-hayʼah</title> of <persName key="person_24458289" ref="http://www.viaf.org/viaf/24458289/" type="standard" xml:lang="ar-Latn-x-lc">Jighmīnī, Maḥmūd ibn Muḥammad, d. 1221?</persName>
                      </note>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
                   <msItem xml:id="RAS_Arabic_70-item2" n="b">
                      <author key="person_292509212" ref="http://viaf.org/viaf/292509212/">
-                        <persName xml:lang="fa-Latn-x-lc" type="standard">Gunābādī, Muẓaffar ibn Muḥammad Qāsim, d. 1621 or 2</persName>
+                        <persName xml:lang="fa-Latn-x-lc" type="standard">Gunābādī, Muẓaffar ibn Muḥammad Qāsim, d. 1621 or 2</persName>
                         <persName xml:lang="fa" type="alt">گنابادى، مظفر بن محمد قاسم</persName>
                         <persName xml:lang="ar" type="alt">جنابادى، مظفر بن محمد قاسم</persName>
                      </author>
@@ -69,7 +69,7 @@
                      <title xml:lang="fa" key="work_7811">شرح بیست باب</title>
                      <incipit xml:lang="fa"/>
                      <explicit xml:lang="fa" defective="true"/>
-                     <note>A commentary on <title>Bīst Bāb dar taqvīm</title> by <persName xml:lang="fa-Latn-x-lc" type="standard" key="person_f704">Birjandī, ʻAbd al-ʻAlī ibn Muḥammad ibn Ḥusayn, 16th cent</persName>
+                     <note>A commentary on <title>Bīst Bāb dar taqvīm</title> by <persName xml:lang="fa-Latn-x-lc" type="standard" key="person_7603024" ref="http://www.viaf.org/viaf/7603024/">Birjandī, ʻAbd al-ʻAlī ibn Muḥammad ibn Ḥusayn, <date calendar="#Gregorian" notBefore="1500" notAfter="1600">16th cent.</date></persName>
                      </note>
                      <textLang mainLang="fa">Persian</textLang>
                   </msItem>


### PR DESCRIPTION
This PR fixes the authority records for "Birjandī, ʻAbd al-ʻAlī ibn Muḥammad ibn Ḥusayn" to normalize references to this person and consolidate them under the same VIAF record.

This arose out of a conversation at the Islamic Scientific Manuscripts Initiative. 