### PR TITLE
Added links to Digital bodleian from Oxford Fihrist records

### DIFF
--- a/collections/oxford university/MS_Arab_c_90.xml
+++ b/collections/oxford university/MS_Arab_c_90.xml
@@ -66,11 +66,6 @@
                            Theology, and Science; 87. Leiden: Brill, 2014.</bibl>
                         <bibl type="related"><ref target="http://cosmos.bodley.ox.ac.uk/">Link to
                               teaching materials related to the Book of Curiosities.</ref></bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/36ebabd9-4d62-4d8e-8e7b-1afd048e872e"
-                              >Digitised version of MS. Arab. c. 90</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>

--- a/collections/oxford university/MS_Arab_d_138.xml
+++ b/collections/oxford university/MS_Arab_d_138.xml
@@ -100,7 +100,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a13ff6ad-5858-45f1-9b06-56e034d68500"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Arab_d_221.xml
+++ b/collections/oxford university/MS_Arab_d_221.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1cb03db3-43ac-41b4-98e0-58c81144704d"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Arab_d_84.xml
+++ b/collections/oxford university/MS_Arab_d_84.xml
@@ -304,9 +304,9 @@
                      </availability>
                   </adminInfo>
                   <surrogates>
-                       <bibl type="digital-fascimile" subtype="full">
+                       <bibl type="digital-facsimile" subtype="partial">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2a9a14c0-1dc1-4b6b-b4a2-740550aceb1a">
-                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                            <title>Digital Bodleian</title></ref> <note>(Single image of fol. 24b-25a, Maqāla fī aghrāḍ kitāb Ma ba’d al-tabī’ah - On the scope of Aristotle's Metaphysics)</note>
                      </bibl>
                   </surrogates>
                </additional>

--- a/collections/oxford university/MS_Arch_Seld_A_11.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_11.xml
@@ -143,7 +143,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/f7abf7d2-d365-4aa9-9f44-ab7d626a4d47"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Bodl_Or_133.xml
+++ b/collections/oxford university/MS_Bodl_Or_133.xml
@@ -55,11 +55,6 @@
                      <note>An astrological work with illustrations</note>
                      
                      <listBibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/3e847457-c129-4c3f-b67b-138573afb1de"
-                              >Digitised version of MS. Bodl. Or. 133.</ref>
-                        </bibl>
                         <bibl>Appendix Astrology</bibl>
                         <bibl>[NAM. 283 (1), with corr. Nic. pp. 541-44]</bibl>
                      </listBibl>
@@ -187,6 +182,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/5c9da286-6a02-406c-b990-0896b8ddbbb0">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Bodl_Or_514.xml
+++ b/collections/oxford university/MS_Bodl_Or_514.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/95786c21-34fa-4164-b32f-46264521e4e6"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Bodl_Or_565.xml
+++ b/collections/oxford university/MS_Bodl_Or_565.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b7258770-61c5-4ff9-b030-7f3fbc379a06"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2f5b1b56-7ed4-4c04-ba1d-02bdc0f9ed90"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Bodl_Or_584.xml
+++ b/collections/oxford university/MS_Bodl_Or_584.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/9ac310aa-27e6-485c-8d44-c1391f5212ff"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Bodl_Or_793.xml
+++ b/collections/oxford university/MS_Bodl_Or_793.xml
@@ -60,11 +60,6 @@
                      <listBibl>
                         <bibl>GAL I 33-36</bibl>
                         <bibl>[NAM. 1, with corrig. Nicoll p. 507]</bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/9cd7007d-28e6-4e9e-8fd5-8c3586ce56a3"
-                              >Digitised version of MS. Bodl. Or. 793.</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -99,7 +94,7 @@
                      </availability>
                   </adminInfo>
                   <surrogates>
-                       <bibl type="digital-fascimile" subtype="full">
+                       <bibl type="digital-facsimile" subtype="full">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1d091ec9-33f8-42d9-a620-141dfc7b1816">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>

--- a/collections/oxford university/MS_Bruce_50.xml
+++ b/collections/oxford university/MS_Bruce_50.xml
@@ -203,7 +203,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/602587db-2762-41f4-a131-cba33e83e563"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Canonici_Or_122.xml
+++ b/collections/oxford university/MS_Canonici_Or_122.xml
@@ -98,7 +98,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a25334b2-9fab-4931-9a0b-14eaa4ab898f"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Digby_Or_17.xml
+++ b/collections/oxford university/MS_Digby_Or_17.xml
@@ -80,7 +80,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1f3bf8e5-079f-47e0-a914-7d53d1684dd9"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Elliott_192.xml
+++ b/collections/oxford university/MS_Elliott_192.xml
@@ -132,7 +132,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ed3dac54-cfc0-43b5-9eb7-6214abe98094"><title>Digital Bodleian</title></ref> <note>(704 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Elliott_239.xml
+++ b/collections/oxford university/MS_Elliott_239.xml
@@ -155,7 +155,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e800b13a-6699-49ae-9bc2-c9b8c35b7a25"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Elliott_287.xml
+++ b/collections/oxford university/MS_Elliott_287.xml
@@ -98,7 +98,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2947cab3-0155-41e1-b67f-746941ac9925"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Elliott_318.xml
+++ b/collections/oxford university/MS_Elliott_318.xml
@@ -102,7 +102,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/af26c97f-2ee6-402e-aeb3-7df95b7eb36f"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Greaves_25.xml
+++ b/collections/oxford university/MS_Greaves_25.xml
@@ -106,7 +106,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1276a0c8-9666-4c88-8a5e-97729bd616ad"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Greaves_42.xml
+++ b/collections/oxford university/MS_Greaves_42.xml
@@ -58,9 +58,6 @@
                      <listBibl>
                         <bibl>GAL I 477</bibl>
                         <bibl>[UAM. 884]</bibl>
-                        <bibl type="related"><ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/e1cc5c2d-f2a7-45a0-9738-e952e50ec5f6"
-                              >View the digitized maps from MS. Greaves 42.</ref></bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -92,6 +89,12 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="partial">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c99d2caf-7abc-4593-97a7-02bf17213f35">
+                               <title>Digital Bodleian</title></ref> <note>(31 illustrations)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Greaves_5.xml
+++ b/collections/oxford university/MS_Greaves_5.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/8772a1fe-ab37-45d6-80ff-f1430f0e6585"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/4c03cc08-80b8-45bc-94f9-a02be81a4784"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_102.xml
+++ b/collections/oxford university/MS_Huntington_102.xml
@@ -84,7 +84,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2854cb0a-53dd-4551-966f-18b7414c8ea9"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_156.xml
+++ b/collections/oxford university/MS_Huntington_156.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1c070987-95ac-4995-96cf-97ac3841b0d7"><title>Digital Bodleian</title></ref> <note>(3 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_195.xml
+++ b/collections/oxford university/MS_Huntington_195.xml
@@ -83,7 +83,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/05c4dcf7-d819-4c38-83c8-fc7c7ba340d7"><title>Digital Bodleian</title></ref> <note>(4 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_196.xml
+++ b/collections/oxford university/MS_Huntington_196.xml
@@ -80,7 +80,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b13163d3-aa78-42c3-9f9a-462a53b52265"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_202.xml
+++ b/collections/oxford university/MS_Huntington_202.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ba2ae4dd-4aaf-4b52-a404-078b529689c0"><title>Digital Bodleian</title></ref> <note>(3 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_212.xml
+++ b/collections/oxford university/MS_Huntington_212.xml
@@ -59,9 +59,6 @@
                      <listBibl>
                         <bibl>GAL I 223</bibl>
                         <bibl>UAM. 899</bibl>
-                        <bibl type="related">
-                           <ref target="http://digital.bodleian.ox.ac.uk/inquire/p/bdbddcbe-085f-4c56-ad4b-0748548082ad">Digitised version of MS. Huntington 212</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -90,6 +87,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="http://digital.bodleian.ox.ac.uk/inquire/p/fba70a3f-2cf2-40cd-8d43-017b3eaed5c3">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Huntington_214.xml
+++ b/collections/oxford university/MS_Huntington_214.xml
@@ -138,7 +138,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/33861ddb-eb59-4aef-9ded-3eaf11298d7a"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_263.xml
+++ b/collections/oxford university/MS_Huntington_263.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/6e1da8a7-936e-4604-920f-b745a1cdf235"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_264.xml
+++ b/collections/oxford university/MS_Huntington_264.xml
@@ -79,7 +79,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a936441f-8f37-43f2-be42-8022f58a63a2"><title>Digital Bodleian</title></ref> <note>(8 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_326.xml
+++ b/collections/oxford university/MS_Huntington_326.xml
@@ -80,7 +80,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/13b58ccc-4ee8-4e4a-b852-6a2a6f426505"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_390.xml
+++ b/collections/oxford university/MS_Huntington_390.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/276741ad-3ae9-4dcc-9380-c61758e57c1a"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_427.xml
+++ b/collections/oxford university/MS_Huntington_427.xml
@@ -366,7 +366,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/01fbd47d-985a-4135-a1e2-3e4fd2808d6c"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_491.xml
+++ b/collections/oxford university/MS_Huntington_491.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/fce81488-b932-42e9-9fdf-70cef64d07bc"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_541.xml
+++ b/collections/oxford university/MS_Huntington_541.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c221375d-d7af-47b0-9786-346ff4e6f800"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_582.xml
+++ b/collections/oxford university/MS_Huntington_582.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/277e87b4-0309-475c-9268-1f797c7983a5"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_596.xml
+++ b/collections/oxford university/MS_Huntington_596.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/956f139a-47cf-4eeb-a531-d77b55426bad"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_615.xml
+++ b/collections/oxford university/MS_Huntington_615.xml
@@ -76,7 +76,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/9c99fb80-6ebf-4326-8a54-c21823407cc4"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_donat_31.xml
+++ b/collections/oxford university/MS_Huntington_donat_31.xml
@@ -215,7 +215,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1e6ef3f6-950c-463e-bfd2-37d0b5aa0d92"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Huntington_donat_7.xml
+++ b/collections/oxford university/MS_Huntington_donat_7.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/f865c70b-72ad-428e-8218-50ce8d87c042"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Hyde_10.xml
+++ b/collections/oxford university/MS_Hyde_10.xml
@@ -94,7 +94,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/23c9305a-844e-48c8-8e76-8832f5e42b2e"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Hyde_35.xml
+++ b/collections/oxford university/MS_Hyde_35.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/0a700b88-66a1-4846-b6ee-d20ab4e5795e"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Laud_Or_134.xml
+++ b/collections/oxford university/MS_Laud_Or_134.xml
@@ -55,9 +55,6 @@
                         <bibl>
                            <ref target="http://archive.org/stream/catalogueofpersi01bodluoft#page/312/mode/2up">no. 930</ref>
                         </bibl>
-                        <bibl type="related">
-                           <ref target="http://digital.bodleian.ox.ac.uk/inquire/p/99769280-60d9-4722-9fe1-92ef597d3bca">Digitized version of MS. Laud Or. 134</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
                   </msItem>
@@ -92,6 +89,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="http://digital.bodleian.ox.ac.uk/inquire/p/17114572-bc88-42fa-8aee-eb261d68d84d">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Laud_Or_139.xml
+++ b/collections/oxford university/MS_Laud_Or_139.xml
@@ -133,7 +133,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/bcc68154-303d-43cb-bee6-c5ddffcd8d39"><title>Digital Bodleian</title></ref> <note>(3 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Laud_Or_149.xml
+++ b/collections/oxford university/MS_Laud_Or_149.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c7533391-ccd2-4f99-8ea9-114845e3b8c3"><title>Digital Bodleian</title></ref> <note>(31 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Laud_Or_210.xml
+++ b/collections/oxford university/MS_Laud_Or_210.xml
@@ -109,7 +109,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/07882a4f-58e8-471c-94b4-a935e398cb94"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Laud_Or_49.xml
+++ b/collections/oxford university/MS_Laud_Or_49.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7084c7f5-110a-483b-b07a-f803c6fc9639"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_137.xml
+++ b/collections/oxford university/MS_Marsh_137.xml
@@ -110,7 +110,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/63730436-c094-4dd1-a6a3-768591601bc3"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_144.xml
+++ b/collections/oxford university/MS_Marsh_144.xml
@@ -62,9 +62,6 @@
                         <bibl>
                            <ref target="http://digital.info.soas.ac.uk/10500/#page/306/mode/2up">View the 1787 printed catalogue</ref>
                         </bibl>
-                        <bibl type="related">
-                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/22eeaaae-5081-4e87-b559-7111e74c2a26">View Digitised version of MS. Marsh 144</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -90,6 +87,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c1caa84c-f6d2-483f-9eb4-2439cccdc801">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Marsh_156.xml
+++ b/collections/oxford university/MS_Marsh_156.xml
@@ -80,7 +80,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c670c3fc-1fbf-447e-a585-170037eb3986"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/5dfc5233-c661-45ce-864e-74336e8da87b"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_206.xml
+++ b/collections/oxford university/MS_Marsh_206.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/bac0ae90-281e-439c-83a8-fe0a0a11b267"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_215.xml
+++ b/collections/oxford university/MS_Marsh_215.xml
@@ -152,7 +152,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/cd5ad9bd-0ec2-4619-8a8a-201e3390eb30"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/0dd8c0a0-47f1-4fb9-823b-160f5d2658f5"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_233.xml
+++ b/collections/oxford university/MS_Marsh_233.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/fe5616d9-4ec7-4bf5-bd68-b237ac060ea1"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_248.xml
+++ b/collections/oxford university/MS_Marsh_248.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1ce71856-bd99-4226-947e-e99638a83963"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_294.xml
+++ b/collections/oxford university/MS_Marsh_294.xml
@@ -59,11 +59,6 @@
                      <listBibl>
                         <bibl>GAL II 464</bibl>
                         <bibl>UAM. 935, with corrig. Nicoll p. 602</bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/d6eac491-55af-4891-84f0-30d97cb0fcbe"
-                              >Digitised version of MS. Marsh 294</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -95,6 +90,13 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/19589637-02a0-44cb-b55a-9ccf28e356bc">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
+                   
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Marsh_410.xml
+++ b/collections/oxford university/MS_Marsh_410.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/4e2a91ea-c47b-4033-af13-97d169f686a1"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_517.xml
+++ b/collections/oxford university/MS_Marsh_517.xml
@@ -96,7 +96,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/04b49455-71f1-4c34-8cf4-5c3791a6e58c"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_54.xml
+++ b/collections/oxford university/MS_Marsh_54.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/02bbcbbf-462c-4ea8-9b83-6d8ba8748e2c"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_667.xml
+++ b/collections/oxford university/MS_Marsh_667.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c10cfb01-d848-4af6-89cd-029d89f0fd1b"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_70.xml
+++ b/collections/oxford university/MS_Marsh_70.xml
@@ -102,7 +102,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c3201d58-0ea2-42c6-87c9-0912a023bcd0"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Marsh_98.xml
+++ b/collections/oxford university/MS_Marsh_98.xml
@@ -84,7 +84,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/6fd714fe-a149-4c3d-b7e4-f6dda3bcc34b"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Ouseley_140.xml
+++ b/collections/oxford university/MS_Ouseley_140.xml
@@ -59,9 +59,6 @@
                         <bibl>
                            <ref target="http://archive.org/stream/catalogueofpersi01bodluoft#page/230/mode/2up">no. 525</ref>
                         </bibl>
-                        <bibl type="related">
-                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/36d8b0a6-0e70-4480-a00a-eb095b18c304">Digitized version of MS. Ouseley 140</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
                   </msItem>
@@ -103,6 +100,12 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/44c54e4b-d102-4329-97cc-9607bdd9bee1">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Ouseley_379-381.xml
+++ b/collections/oxford university/MS_Ouseley_379-381.xml
@@ -68,24 +68,6 @@
                               target="http://archive.org/stream/catalogueofpersi01bodluoft#page/210/mode/2up"
                               >no. 442</ref>
                         </bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/d946f398-3800-4ce9-95c1-629c91de62c4"
-                              >View partial digitised version (illustrations only) of MS. Ouseley
-                              379</ref>
-                        </bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/a32c6e17-6bee-43f7-a939-78b70c441f94"
-                              >View partial digitised version (illustrations only) of MS. Ouseley
-                              380</ref>
-                        </bibl>
-                        <bibl type="related">
-                           <ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/c171daf5-f471-4551-9917-8db75f9b6ec2"
-                              >View partial digitised version (illustrations only) of MS. Ouseley
-                              381</ref>
-                        </bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
                   </msItem>
@@ -125,6 +107,20 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="partial">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/65903835-6eb9-4709-9e96-a07e29f1cb1b">
+                               <title>Digital Bodleian</title></ref> <note>(20 illustrations from MS. Ouseley 379)</note>
+                       </bibl>
+                       <bibl type="digital-facsimile" subtype="partial">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e655262b-b0e7-4d0d-8951-fba99712bb4a">
+                               <title>Digital Bodleian</title></ref> <note>(21 illustrations from MS. Ouseley 380)</note>
+                       </bibl>
+                       <bibl type="digital-facsimile" subtype="partial">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1104b92d-4424-477d-b8f3-1899a08573df">
+                               <title>Digital Bodleian</title></ref> <note>(39 illustrations from MS. Ouseley 381)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Ouseley_Add_1.xml
+++ b/collections/oxford university/MS_Ouseley_Add_1.xml
@@ -114,7 +114,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/9d7d382f-9ea8-42e3-bd86-5ccb1bde5854"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Ouseley_Add_175.xml
+++ b/collections/oxford university/MS_Ouseley_Add_175.xml
@@ -127,7 +127,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/4d01494c-8aba-4fea-b8f9-e7b70c826d0f"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Ouseley_Add_176.xml
+++ b/collections/oxford university/MS_Ouseley_Add_176.xml
@@ -58,11 +58,6 @@
                            <ref
                               target="http://archive.org/stream/catalogueofpersi01bodluoft#page/226/mode/2up"
                               >no. 501</ref>
-                           <bibl type="related">
-                              <ref
-                                 target="https://digital.bodleian.ox.ac.uk/inquire/p/7c98adf0-d0e2-444a-aa57-62b05764d036"
-                                 >Digitized version of MS. Ouseley Add. 176</ref>
-                           </bibl>
                         </bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
@@ -109,6 +104,12 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/bcbfd832-086b-4874-80f8-87500e0de704">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Pers_d_102.xml
+++ b/collections/oxford university/MS_Pers_d_102.xml
@@ -60,9 +60,6 @@
                         <bibl><ref
                               target="https://archive.org/stream/catalogueofpersi03bodluoft#page/92/mode/2up"
                               >No. 2485</ref></bibl>
-                        <bibl type="related"><ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/fbeed076-9372-46c2-a195-575a8f2c9409"
-                              >View digitized version of MS. Pers. d. 102.</ref></bibl>
                      </listBibl>
                      <textLang mainLang="fa">Persian</textLang>
                   </msItem>
@@ -85,8 +82,8 @@
                </physDesc>
                <history>
                   <origin>
-                     <origDate calendar="#Hijri-qamari">n.d. [10th century, before 971]</origDate>
-                     <origDate calendar="#Gregorian" atMost="1563">n.d.[16th century, before
+                     <origDate calendar="#Hijri-qamari" notAfter="1563">n.d. [10th century, before 971]</origDate>
+                     <origDate calendar="#Gregorian" notAfter="1563">n.d.[16th century, before
                         1563]</origDate>
                   </origin>
                   <provenance><persName key="person_7740130">James Atkinson</persName></provenance>
@@ -109,6 +106,13 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="full">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/cce97ab5-19e9-4fab-bc06-5a3560101156">
+                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                       </bibl>
+                   </surrogates>
+                   
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Pers_e_26.xml
+++ b/collections/oxford university/MS_Pers_e_26.xml
@@ -97,7 +97,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b54c3f88-a3bf-4cfe-a743-e4fd42c8b67c"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_125.xml
+++ b/collections/oxford university/MS_Pococke_125.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/566cf456-3bc5-4188-b5ff-ad7aadd2f7a5"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_131.xml
+++ b/collections/oxford university/MS_Pococke_131.xml
@@ -80,7 +80,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a7be4e8a-14b6-4374-ab71-a771c6e07b6e"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_181.xml
+++ b/collections/oxford university/MS_Pococke_181.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/77c8ab65-b3a0-4d0c-bca3-31f86ed86e51"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_206.xml
+++ b/collections/oxford university/MS_Pococke_206.xml
@@ -86,7 +86,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/8a928cc9-d306-4ef3-a910-726a35780a73"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_248.xml
+++ b/collections/oxford university/MS_Pococke_248.xml
@@ -83,7 +83,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/6a64cbfc-2c30-4244-afed-c6016eb2bab4"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_319.xml
+++ b/collections/oxford university/MS_Pococke_319.xml
@@ -83,7 +83,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/cf465635-627e-4ad6-bd63-a889996a5cac"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_356.xml
+++ b/collections/oxford university/MS_Pococke_356.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b3bfdb81-05fc-4b8d-859a-83d5cca0e3cb"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_369.xml
+++ b/collections/oxford university/MS_Pococke_369.xml
@@ -111,7 +111,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/5c21787e-b587-4f0d-b81c-8fbd94d21663"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_375.xml
+++ b/collections/oxford university/MS_Pococke_375.xml
@@ -59,9 +59,6 @@
                      <listBibl>
                         <bibl>GAL I 477</bibl>
                         <bibl>[UAM. 887]</bibl>
-                        <bibl type="related"><ref
-                              target="https://digital.bodleian.ox.ac.uk/inquire/p/cc2debab-70f5-4b82-9bab-7235fdb89e43"
-                           >View the digitized maps from MS. Pococke 375</ref></bibl>
                      </listBibl>
                      <textLang mainLang="ar">Arabic</textLang>
                   </msItem>
@@ -95,6 +92,12 @@
                            for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
+                   <surrogates>
+                       <bibl type="digital-facsimile" subtype="partial">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ced0d8bd-1019-4af2-9086-e411115f1507">
+                               <title>Digital Bodleian</title></ref> <note>(70 illustrations)</note>
+                       </bibl>
+                   </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/oxford university/MS_Pococke_400.xml
+++ b/collections/oxford university/MS_Pococke_400.xml
@@ -83,7 +83,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="full"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/8face4cc-d7dc-4ec6-8315-64b8c171dd76"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_47.xml
+++ b/collections/oxford university/MS_Pococke_47.xml
@@ -82,7 +82,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/28263757-89ec-486c-a80e-8032d3bab6c2"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Pococke_66.xml
+++ b/collections/oxford university/MS_Pococke_66.xml
@@ -81,7 +81,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/3f4dabb0-b746-4743-a01b-aea7f9457212"><title>Digital Bodleian</title></ref> <note>(single sample image)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Thurston_11.xml
+++ b/collections/oxford university/MS_Thurston_11.xml
@@ -85,7 +85,7 @@
                         <p>Entry to read in the Library is permitted only on presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-               </additional>
+               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/c0208b9d-c07f-47fe-845c-f3e38e9cb9f9"><title>Digital Bodleian</title></ref> <note>(2 selected images only)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>

--- a/collections/oxford university/MS_Whinfield_33.xml
+++ b/collections/oxford university/MS_Whinfield_33.xml
@@ -100,7 +100,7 @@
                      </availability>
                   </adminInfo>
                   <surrogates>
-                       <bibl type="digital-fascimile" subtype="full">
+                       <bibl type="digital-facsimile" subtype="full">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/6b3da54c-5f21-4dda-af76-726fee02d9e5">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>

--- a/collections/oxford university/MS_Whinfield_4.xml
+++ b/collections/oxford university/MS_Whinfield_4.xml
@@ -93,7 +93,7 @@
                      </availability>
                   </adminInfo>
                   <surrogates>
-                       <bibl type="digital-fascimile" subtype="full">
+                       <bibl type="digital-facsimile" subtype="full">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ccce57a1-ae6f-45f4-8e21-8fea2cc803f6">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>

--- a/collections/oxford university/MS_Whinfield_4.xml
+++ b/collections/oxford university/MS_Whinfield_4.xml
@@ -93,7 +93,7 @@
                      </availability>
                   </adminInfo>
                   <surrogates>
-                       <bibl type="digital-facsimile" subtype="full">
+                       <bibl type="digital-fascimile" subtype="full">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ccce57a1-ae6f-45f4-8e21-8fea2cc803f6">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>

--- a/processing/conversion_scripts/insert-digbod-links.xsl
+++ b/processing/conversion_scripts/insert-digbod-links.xsl
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns="http://www.tei-c.org/ns/1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:saxon="http://saxon.sf.net/"
+    xmlns:bod="http://www.bodleian.ox.ac.uk/bdlss"
+    exclude-result-prefixes="xs bod saxon tei"
+    version="2.0">
+    
+    <xsl:variable name="newline" select="'&#10;'"/>
+    <xsl:variable name="mappings" as="xs:string*" select="tokenize(unparsed-text('/tmp/matched_fihrist_in_digbod.txt', 'utf-8'), '\r?\n')"/>
+    <xsl:variable name="mappedshelfmarks" as="xs:string*" select="for $m in $mappings return tokenize($m, '\t')[1]"/>
+    <xsl:variable name="recordshelfmark" as="xs:string" select="normalize-space((tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc/tei:msIdentifier/tei:idno)[1]/string())"/>
+
+    <xsl:template match="/">
+        <xsl:if test="$recordshelfmark = $mappedshelfmarks">
+            <xsl:apply-templates/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="processing-instruction('xml-model')">
+        <xsl:value-of select="$newline"/>
+        <xsl:copy/>
+        <xsl:if test="preceding::processing-instruction('xml-model')"><xsl:value-of select="$newline"/></xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="/tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc/tei:additional[not(tei:surrogates)]">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+            <xsl:element namespace="http://www.tei-c.org/ns/1.0" name="surrogates">
+                <xsl:for-each select="$mappings[tokenize(., '\t')[1] = $recordshelfmark]">
+                    <xsl:variable name="uuid" as="xs:string" select="tokenize(., '\t')[3]"/>
+                    <xsl:variable name="completeness" as="xs:string" select="tokenize(., '\t')[4]"/>
+                    <xsl:variable name="numsurfaces" as="xs:string" select="tokenize(., '\t')[5]"/>            
+                    <xsl:element namespace="http://www.tei-c.org/ns/1.0" name="bibl">
+                        <xsl:attribute name="type">
+                            <xsl:text>digital-facsimile</xsl:text>
+                        </xsl:attribute>
+                        <xsl:attribute name="subtype">
+                            <xsl:choose>
+                                <xsl:when test="$completeness eq 'complete'">
+                                    <xsl:text>full</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>partial</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:element namespace="http://www.tei-c.org/ns/1.0" name="ref">
+                            <xsl:attribute name="target">
+                                <xsl:text>https://digital.bodleian.ox.ac.uk/inquire/p/</xsl:text>
+                                <xsl:value-of select="$uuid"/>
+                            </xsl:attribute>
+                            <xsl:element namespace="http://www.tei-c.org/ns/1.0" name="title">
+                                <xsl:text>Digital Bodleian</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:text> </xsl:text>
+                        <xsl:element namespace="http://www.tei-c.org/ns/1.0" name="note">
+                            <xsl:text>(</xsl:text>
+                            <xsl:choose>
+                                <xsl:when test="$completeness eq 'complete'">
+                                    <xsl:text>full digital facsimile</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="$numsurfaces eq '1'">
+                                    <xsl:text>single sample image</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$numsurfaces"/>
+                                    <xsl:text> selected images only</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            <xsl:text>)</xsl:text>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:for-each>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="*">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="text()|comment()|processing-instruction()">
+        <xsl:copy/>
+    </xsl:template>
+    
+    
+</xsl:stylesheet>

--- a/processing/manuscripts.xquery
+++ b/processing/manuscripts.xquery
@@ -61,7 +61,7 @@ declare variable $collection := collection('../collections/?select=*.xml;recurse
                     { bod:materials($ms//tei:msDesc//tei:physDesc//tei:supportDesc[@material], 'ms_materials_sm', 'Unknown') }
                     { bod:physForm($ms//tei:physDesc/tei:objectDesc, 'ms_physform_sm', 'Not specified') }
                     { bod:trueIfExists($ms//tei:sourceDesc//tei:decoDesc/tei:decoNote, 'ms_deconote_b') }
-                    { (: Fihrist doesn't consistently markup links to digital copies: bod:digitized($ms//tei:sourceDesc//tei:surrogates/tei:bibl, 'ms_digitized_s'):)() }
+                    { bod:digitized($ms//tei:sourceDesc//tei:surrogates/tei:bibl, 'ms_digitized_s') }
                     { bod:languages($ms//tei:sourceDesc//tei:textLang, 'lang_sm') }
                     { bod:centuries(
                         $ms//tei:origin//tei:origDate[@calendar = ('#Gregorian', '#Hijri-qamari', '#Hindu')], 


### PR DESCRIPTION
Hi Alasdair,

I have run a comparison between the Oxford shelfmarks in Fihrist and those in Digital Bodleian's "Oriental" collection, and found 67 new matches. I have inserted those into the TEI records using the surrogates element, and changed the existing ones to match. These will display as links from the records on the Fihrist web site to the digital copies in Digital Bodleian. It also means @ahankinson will be able to set up Digital Bodleian to automatically link the other way, to the catalogue records on Fihrist, from a side panel when viewing the digital copies.

In total, there are now 30 Oxford Fihrist manuscripts which have been fully digitized, and 52 for which we have one or more sample images. These are listed at the following URLs (only accessible within the Bodleian staff network):

http://fihrist-qa.bodleian.ox.ac.uk/?f[ms_digitized_s][]=Yes&f[type][]=manuscript
http://fihrist-qa.bodleian.ox.ac.uk/?f[ms_digitized_s][]=Selected+pages+only&f[type][]=manuscript

If those look OK, please merge this pull request (you can do that by following the link in the notification email and clicking the green "Merge pull request" button) and I'll publish to the public Fihrist web site.

Andrew.