### PR TITLE
Remove facsimile link for MS. Ouseley 24

### DIFF
--- a/collections/oxford university/MS_Ouseley_24.xml
+++ b/collections/oxford university/MS_Ouseley_24.xml
@@ -119,14 +119,6 @@
                            further information on the availability of this manuscript</p>
                      </availability>
                   </adminInfo>
-                  <surrogates>
-                     <bibl type="digital-facsimile" subtype="full">
-                        <ref
-                           target="https://digital.bodleian.ox.ac.uk/objects/3dc86f6f-1853-431e-91c1-e557ec06cdbc/">
-                           <title>Digital Bodleian</title></ref>
-                        <note>(full digital facsimile)</note>
-                     </bibl>
-                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
The images associated with the shelfmark actually belonged to MS. Ouseley Add. 24 and had to be removed from DB.