### PR TITLE
ARKs updates 2024 03 04 (Bodleian-only changes)

### DIFF
--- a/collections/oxford university/MS_Bodl_Or_191.xml
+++ b/collections/oxford university/MS_Bodl_Or_191.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bodl. Or. 191</idno>
+                        <idno type="ieArk">ark:29072/x0df65v842zt</idno>
+                        <idno type="crArk">ark:29072/x0dj52w52681</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2109</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Bodl_Or_394.xml
+++ b/collections/oxford university/MS_Bodl_Or_394.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bodl. Or. 394</idno>
+                        <idno type="ieArk">ark:29072/x0d791sg76bb</idno>
+                        <idno type="crArk">ark:29072/x0db78tc59n3</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2111</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Bodl_Or_403.xml
+++ b/collections/oxford university/MS_Bodl_Or_403.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bodl. Or. 403</idno>
+                        <idno type="ieArk">ark:29072/x0d217qq09q0</idno>
+                        <idno type="crArk">ark:29072/x0d504rk931w</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2110</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Bodl_Or_41.xml
+++ b/collections/oxford university/MS_Bodl_Or_41.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bod. Or. 41</idno>
+                        <idno type="ieArk">ark:29072/x0dn39x209ks</idno>
+                        <idno type="crArk">ark:29072/x0dr26xx92w3</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2108</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Bodl_Or_515-518.xml
+++ b/collections/oxford university/MS_Bodl_Or_515-518.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bodl. Or. 515-518</idno>
+                        <idno type="ieArk">ark:29072/x0xp68kg00gf</idno>
+                        <idno type="crArk">ark:29072/x0xs55mb83s4</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2128</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Bodl_Or_75.xml
+++ b/collections/oxford university/MS_Bodl_Or_75.xml
@@ -51,6 +51,8 @@
                         <repository>Bodleian Library</repository>
                         <collection type="main">Oriental Manuscripts</collection>
                         <idno>MS. Bodl. Or. 75</idno>
+                        <idno type="ieArk">ark:29072/x0dv13zt7669</idno>
+                        <idno type="crArk">ark:29072/x0dz010q59hc</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2125, 2214, 2226</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Huntington_507.xml
+++ b/collections/oxford university/MS_Huntington_507.xml
@@ -52,6 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Huntington</collection>
                         <idno>MS. Huntongton 507</idno>
+                        <idno type="ieArk">ark:29072/x0cv43nx4338</idno>
+                        <idno type="crArk">ark:29072/x0cz30pt26d4</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2123</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Laud_Or_66.xml
+++ b/collections/oxford university/MS_Laud_Or_66.xml
@@ -52,6 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Laud</collection>
                         <idno>MS. Laud 66</idno>
+                        <idno type="ieArk">ark:29072/x008612p57gj</idno>
+                        <idno type="crArk">ark:29072/x0cn69m476gk</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2124</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Laud_Or_76.xml
+++ b/collections/oxford university/MS_Laud_Or_76.xml
@@ -52,6 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Laud</collection>
                         <idno>MS. Laud. 76</idno>
+                        <idno type="ieArk">ark:29072/x0xg94hn67rh</idno>
+                        <idno type="crArk">ark:29072/x0cr56n159sf</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2126</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Marsh_633.xml
+++ b/collections/oxford university/MS_Marsh_633.xml
@@ -52,6 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Marsh</collection>
                         <idno>MS. Marsh 633</idno>
+                        <idno type="ieArk">ark:29072/x0cv43nx292b</idno>
+                        <idno type="crArk">ark:29072/x0cr56n145rc</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2127</idno>
                         </altIdentifier>


### PR DESCRIPTION
This adds back in ieArks and crArks that were removed when the files were updated. It also mints new ARKs for MS Bodl Or 515-518, ready for indexing on MARCO.