### PR TITLE
add arks for Oxford materials

### DIFF
--- a/collections/keble college (university of oxford)/Keble_MS_90.xml
+++ b/collections/keble college (university of oxford)/Keble_MS_90.xml
@@ -42,6 +42,8 @@
                   <repository>Keble College Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>Keble MS. 90</idno>
+                  <idno type="ieArk">ark:29072/k00r967366g5</idno>
+                  <idno type="crArk">ark:29072/k00v838049s1</idno>
                </msIdentifier>
                <msContents>
                   <summary/>

--- a/collections/keble college (university of oxford)/Keble_MS_91.xml
+++ b/collections/keble college (university of oxford)/Keble_MS_91.xml
@@ -42,6 +42,8 @@
                   <repository>Keble College Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>Keble MS. 91</idno>
+                  <idno type="ieArk">ark:29072/k00z708w333v</idno>
+                  <idno type="crArk">ark:29072/k012579s16dq</idno>
                </msIdentifier>
                <msContents>
                   <summary>A copy of the second volume of Abū Bakr al-Ṭurṭūshī's Sirāj al-mulūk, the

--- a/collections/keble college (university of oxford)/Keble_MS_92.xml
+++ b/collections/keble college (university of oxford)/Keble_MS_92.xml
@@ -42,6 +42,8 @@
                   <repository>Keble College Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>Keble MS. 92</idno>
+                  <idno type="ieArk">ark:29072/k01544bn99qd</idno>
+                  <idno type="crArk">ark:29072/k01831cj831g</idno>
                </msIdentifier>
                <msContents>
                   <summary>A copy of the Holy Qur'an.</summary>

--- a/collections/keble college (university of oxford)/Keble_MS_93.xml
+++ b/collections/keble college (university of oxford)/Keble_MS_93.xml
@@ -42,6 +42,8 @@
                   <repository>Keble College Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>Keble MS. 93</idno>
+                  <idno type="ieArk">ark:29072/k01c18df66b7</idno>
+                  <idno type="crArk">ark:29072/k01g05fb49n3</idno>
                </msIdentifier>
                <msContents>
                   <summary>A copy of Asās al-barāhīn by Khalīl ibn Aḥmad al-Ḥanafī on the

--- a/collections/oxford university/MS_Arab_g_42.xml
+++ b/collections/oxford university/MS_Arab_g_42.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Arab. g. 42</idno>
+                  <idno type="ieArk">ark:29072/x0rv042t27cs</idno>
+                  <idno type="crArk">ark:29072/x0rx913q10p3</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Pers_112.xml
+++ b/collections/oxford university/MS_Ind_Inst_Pers_112.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Ind. Inst. Pers. 112</idno>
+                  <idno type="ieArk">ark:29072/x0s1784k9404</idno>
+                  <idno type="crArk">ark:29072/x0s4655g7790</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Pers_71.xml
+++ b/collections/oxford university/MS_Ind_Inst_Pers_71.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Ind. Inst. Pers. 71</idno>
+                  <idno type="ieArk">ark:29072/x0s7526c60mq</idno>
+                  <idno type="crArk">ark:29072/x0sb397843xg</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Pers_80.xml
+++ b/collections/oxford university/MS_Ind_Inst_Pers_80.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Ind. Inst. Pers. 80</idno>
+                  <idno type="ieArk">ark:29072/x0sf2685277p</idno>
+                  <idno type="crArk">ark:29072/x0sj139210jd</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Pers_97.xml
+++ b/collections/oxford university/MS_Ind_Inst_Pers_97.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Ind. Inst. Pers. 97</idno>
+                  <idno type="ieArk">ark:29072/x0sn009x93vv</idno>
+                  <idno type="crArk">ark:29072/x0sq87bt775j</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Turk_10.xml
+++ b/collections/oxford university/MS_Ind_Inst_Turk_10.xml
@@ -39,7 +39,7 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <collection>Shaw Collection</collection>
-                  <idno type="shelfmark">MS. Ind. Inst. Turk. 10</idno>
+                  <idno>MS. Ind. Inst. Turk. 10</idno>
                   <idno type="ieArk">ark:29072/x0x920fw259c</idno>
                   <idno type="crArk">ark:29072/x0x633f0420r</idno>
                   <altIdentifier>

--- a/collections/oxford university/MS_Ind_Inst_Turk_21.xml
+++ b/collections/oxford university/MS_Ind_Inst_Turk_21.xml
@@ -52,8 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Indian Institute</collection>
                         <idno>MS. Ind. Inst. Turk. 21</idno>
-                        <idno type="ieArk"><!--ARK1--></idno>
-                        <idno type="crArk"><!--ARK2--></idno>
+                        <idno type="ieArk">ark:29072/x0wd375w26jc</idno>
+                        <idno type="crArk">ark:29072/x0wh246s09v7</idno>
                         <altIdentifier>
                             <idno type="kut">Kut 116</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Ouseley_Add_14.xml
+++ b/collections/oxford university/MS_Ouseley_Add_14.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Ouseley Add. 14</idno>
+                  <idno type="ieArk">ark:29072/x0st74cq60g8</idno>
+                  <idno type="crArk">ark:29072/x0sx61dm43s4</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Pers_c_17.xml
+++ b/collections/oxford university/MS_Pers_c_17.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Pers. c. 17</idno>
+                  <idno type="ieArk">ark:29072/x0t148fh273b</idno>
+                  <idno type="crArk">ark:29072/x0t435gd10d2</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Pers_c_34.xml
+++ b/collections/oxford university/MS_Pers_c_34.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Pers. c. 34</idno>
+                  <idno type="ieArk">ark:29072/x0t722h893qr</idno>
+                  <idno type="crArk">ark:29072/x0tb09j5771v</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Pers_c_37.xml
+++ b/collections/oxford university/MS_Pers_c_37.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Pers. c. 37</idno>
+                  <idno type="ieArk">ark:29072/x0td96k260b5</idno>
+                  <idno type="crArk">ark:29072/x0th83kz43ns</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Pers_d_57.xml
+++ b/collections/oxford university/MS_Pers_d_57.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts</collection>
                   <idno>MS. Pers. d. 57</idno>
+                  <idno type="ieArk">ark:29072/x0tm70mv26zn</idno>
+                  <idno type="crArk">ark:29072/x0tq57nr108m</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_S_Digby_Or_12.xml
+++ b/collections/oxford university/MS_S_Digby_Or_12.xml
@@ -43,6 +43,8 @@
                   <collection type="main">Oriental Manuscripts Simon Digby Oriental
                      Collection</collection>
                   <idno>MS. S. Digby Or. 12</idno>
+                  <idno type="ieArk">ark:29072/x0tt44pm93k9</idno>
+                  <idno type="crArk">ark:29072/x0tx31qh76w5</idno>
                   <altIdentifier type="former">
                      <idno>SED 16</idno>
                   </altIdentifier>

--- a/collections/oxford university/MS_S_Digby_Or_13.xml
+++ b/collections/oxford university/MS_S_Digby_Or_13.xml
@@ -43,6 +43,8 @@
                   <collection type="main">Oriental Manuscripts Simon Digby Oriental
                      Collection</collection>
                   <idno>MS. S. Digby Or. 13</idno>
+                  <idno type="ieArk">ark:29072/x0v118rd6067</idno>
+                  <idno type="crArk">ark:29072/x0v405s943h3</idno>
                   <altIdentifier type="former">
                      <idno>SED 17</idno>
                   </altIdentifier>

--- a/collections/oxford university/MS_S_Digby_Or_14.xml
+++ b/collections/oxford university/MS_S_Digby_Or_14.xml
@@ -43,6 +43,8 @@
                   <collection type="main">Oriental Manuscripts Simon Digby Oriental
                      Collection</collection>
                   <idno>MS. S. Digby Or. 14</idno>
+                  <idno type="ieArk">ark:29072/x0v692t626tj</idno>
+                  <idno type="crArk">ark:29072/x0v979v3104h</idno>
                   <altIdentifier type="former">
                      <idno>SED 19</idno>
                   </altIdentifier>

--- a/collections/oxford university/MS_S_Digby_Or_15.xml
+++ b/collections/oxford university/MS_S_Digby_Or_15.xml
@@ -43,6 +43,8 @@
                   <collection type="main">Oriental Manuscripts Simon Digby Oriental
                      Collection</collection>
                   <idno>MS. S. Digby Or. 15</idno>
+                  <idno type="ieArk">ark:29072/x0vd66vz93fz</idno>
+                  <idno type="crArk">ark:29072/x0vh53wv76rt</idno>
                   <altIdentifier type="former">
                      <idno>SED 20</idno>
                   </altIdentifier>

--- a/collections/oxford university/MS_S_Digby_Or_18.xml
+++ b/collections/oxford university/MS_S_Digby_Or_18.xml
@@ -43,6 +43,8 @@
                   <collection type="main">Oriental Manuscripts Simon Digby Oriental
                      Collection</collection>
                   <idno>MS. S. Digby Or. 18</idno>
+                  <idno type="ieArk">ark:29072/x0vm40xr602w</idno>
+                  <idno type="crArk">ark:29072/x0vq27zn43cn</idno>
                </msIdentifier>
                <msContents>
                   <summary>A copy of ʻAbd al-Laṭīf Lāhūrī's (?) Khulaṣat al-fiqh.</summary>

--- a/collections/oxford university/MS_Sale_33.xml
+++ b/collections/oxford university/MS_Sale_33.xml
@@ -51,6 +51,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Sale Collection</collection>
                         <idno>MS. Sale 33</idno>
+                        <idno type="ieArk">ark:29072/x0vt150j26pq</idno>
+                        <idno type="crArk">ark:29072/x0vx021f100s</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2132</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Whinfield_44.xml
+++ b/collections/oxford university/MS_Whinfield_44.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts Whinfield Collection</collection>
                   <idno>MS. Whinfield 44</idno>
+                  <idno type="ieArk">ark:29072/x0w089299392</idno>
+                  <idno type="crArk">ark:29072/x0w3763676mx</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>

--- a/collections/oxford university/MS_Whinfield_77.xml
+++ b/collections/oxford university/MS_Whinfield_77.xml
@@ -42,6 +42,8 @@
                   <repository>Bodleian Library</repository>
                   <collection type="main">Oriental Manuscripts Whinfield Collection</collection>
                   <idno>MS. Whinfield 77</idno>
+                  <idno type="ieArk">ark:29072/x0w6634359xs</idno>
+                  <idno type="crArk">ark:29072/x0w95050437v</idno>
                   <altIdentifier>
                      <idno/>
                   </altIdentifier>


### PR DESCRIPTION
also fix for MS. Ind. Inst. Turk 10, which could not be indexed by MARCO as there is an attribute of [@type="shelfmark"] on idno