### PR TITLE
remove repeated arks

### DIFF
--- a/collections/oxford university/MS_Hyde_18.xml
+++ b/collections/oxford university/MS_Hyde_18.xml
@@ -34,8 +34,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>Hyde Collection</collection>
                         <idno>MS. Hyde 18</idno>
-                        <idno type="ieArk">ark:29072/x04f16c413gz</idno>
-                        <idno type="crArk">ark:29072/x04j03d096sn</idno>
+                        <idno type="ieArk">ark:29072/x0h702q714cq</idno>
+                        <idno type="crArk">ark:29072/x0h989r397pw</idno>
                         <altIdentifier>
                             <idno type="ethe">Ethé 2180</idno>
                         </altIdentifier>

--- a/collections/oxford university/MS_Ind_inst_Turk_26.xml
+++ b/collections/oxford university/MS_Ind_inst_Turk_26.xml
@@ -52,8 +52,8 @@
                         <collection type="main">Oriental Manuscripts</collection>
                         <collection>India Institute</collection>
                         <idno>MS. Ind. Inst. Turk. 8</idno>
-                        <idno type="ieArk">ark:29072/x0cv43nx73kh</idno>
-                        <idno type="crArk">ark:29072/x0cz30pt56wc</idno>
+                        <idno type="ieArk">ark:29072/x0hd76s0810z</idno>
+                        <idno type="crArk">ark:29072/x0hh63sw649k</idno>
                         <altIdentifier>
                             <idno type="kut">Kut 103</idno>
                         </altIdentifier>


### PR DESCRIPTION
Re-indexing means that MARCO tried to ingest these materials, and there was a failure because these MS tried to use ARKs that were already defined.

CR ARK `ark:29072/x04j03d096sn` is used by `MS_Laud_Or_70.xml` and `MS_Hyde_18.xml `
CR ARK `ark:29072/x0cz30pt56wc` is used by `MS_Ind_Inst_Turk_8.xml`  and `MS_Ind_inst_Turk_26.xml`

This commit changes those ARKs to new ones.