### PR TITLE
replace ethe vol 2 links.

### DIFF
--- a/collections/oxford university/MS_Arch_Seld_A_16.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_16.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23116">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23116">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -86,7 +89,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775150">Ethé 2052</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=14">Ethé 2052</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>
@@ -108,7 +111,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775150">Ethé 2052</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=14">Ethé 2052</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>
@@ -130,7 +133,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775151">Ethé 2052</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=15">Ethé 2052</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>
@@ -155,7 +158,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775151">Ethé 2052</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=15">Ethé 2052</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Arch_Seld_A_31.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_31.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23250">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_31</idno>
@@ -58,9 +59,7 @@
                                 جدول تقویم منازل قمر, and on fol. 22b sq. the motion of the sun,
                                 جدول حركة الشمس.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,9 +88,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,9 +96,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Arch_Seld_A_33.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_33.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23340">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_33</idno>
@@ -72,9 +73,7 @@
                                 auditor of accounts for the vaḳfs. It was written in Şaʿbān, A.H.
                                 1003= A. D. 1595, April-May. A tuġra on fol. 1a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -107,9 +106,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -117,9 +114,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Arch_Seld_A_35.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_35.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23206">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_35</idno>
@@ -94,9 +95,7 @@
                                 headed: تواریخ بی همتا برای بنای جامع قلعه دلگشا که حضرت وزیر محمد
                                 پاشای دلیر شیرگیر معمور کرده در سنه ۱۰۱۶.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -129,9 +128,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -139,9 +136,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Arch_Seld_A_42.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_42.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23341">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_42</idno>
@@ -54,9 +55,7 @@
                                 book the Turkish words are accompanied with a Roman transliteration
                                 (rekam).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,9 +88,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,9 +96,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Arch_Seld_A_48.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_48.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23259">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_48</idno>
@@ -58,9 +59,7 @@
                                 Last table, on fol. 14b: جدول معرفة احكام خسوف کلی در عقده
                                 ذنب.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=50">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,9 +88,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,9 +96,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Arch_Seld_A_61.xml
+++ b/collections/oxford university/MS_Arch_Seld_A_61.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23343">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Arch_Seld_A_61</idno>
@@ -89,9 +90,7 @@
                                 verses on the margin. The ḫātime is not found in this copy. No
                                 date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=56">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,9 +123,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +131,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_103.xml
+++ b/collections/oxford university/MS_Bodl_Or_103.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23271">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_103</idno>
@@ -50,9 +51,7 @@
                                 more information.</note>
                             <note>Without alphabetical order; first word یکیت = شاب.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=56">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,9 +96,7 @@
                                 Turkish and Arabic. Comp. on G. Flügel iii. p. 233 sq.; W. Pertsch,
                                 p. 82 sq., and Berlin Cat., p. 154; and Rieu, p. 16b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -132,9 +129,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -142,9 +137,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_11.xml
+++ b/collections/oxford university/MS_Bodl_Or_11.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23273">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_11</idno>
@@ -60,9 +61,7 @@
                             <note>Beginning: الحمد لله الذي هدانا للاسلام و جعلنا من امة محمد عليه
                                 الصلوة والسلام الخ. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -95,9 +94,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -105,9 +102,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_17.xml
+++ b/collections/oxford university/MS_Bodl_Or_17.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23127">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23127">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -63,7 +66,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2064</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2064</ref>
                                 </bibl>
                                 <bibl>
                                     <ref target="https://www.proquest.com/books/capitulations-articles-peace-between-majesty-king/docview/2240862463/se-2">(anonymous). (1679). The Capitulations and Articles of

--- a/collections/oxford university/MS_Bodl_Or_173.xml
+++ b/collections/oxford university/MS_Bodl_Or_173.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10540">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10540">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,9 +55,7 @@
                         more information.</note>
                      <note>مهر یوسف on fol. 1b (comp. No. 2262, 9).</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -72,9 +73,7 @@
                         more information.</note>
                      <note>شرح مهر خاتم سلیمان on fol. 4b.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -92,9 +91,7 @@
                         more information.</note>
                      <note>دعای یوسفی on fol. 27a.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -113,9 +110,7 @@
                      <note>شرح دعای قدح on fol. 52b (different from No. 2261, 3; but comp.
                         No. 2260, 16).</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +129,7 @@
                      <note>دعای قدح on fol. 72b (identical with No. 2261, 4, and No. 2260,
                         17).</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -154,9 +147,7 @@
                         more information.</note>
                      <note>دعای اسم اعظم on fol. 85b (different from No. 2261, 13).</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -175,9 +166,7 @@
                      <note>دعای شریف on fol. 92b (also different from No. 2261,8, but comp.
                         No. 2260, 15 and 33).</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -195,9 +184,7 @@
                         more information.</note>
                      <note>شرح دعای کنز العرش on fol. 100b.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -215,9 +202,7 @@
                         more information.</note>
                      <note>شرح دعای حقیر on fol. 116b.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -235,9 +220,7 @@
                         more information.</note>
                      <note>شرح دعای حقیر on fol. 124b.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:
@@ -259,9 +242,7 @@
                         at the end and slightly damaged throughout.</note>
                      <listBibl>
                         <bibl>Appendix Prayers</bibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_177.xml
+++ b/collections/oxford university/MS_Bodl_Or_177.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10543">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10543">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,9 +55,7 @@
                         Arabic, defective at the beginning. Ff. 22-31 are turned upside
                         down.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_178.xml
+++ b/collections/oxford university/MS_Bodl_Or_178.xml
@@ -1,4 +1,6 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10544">
    <teiHeader>
       <fileDesc>
@@ -62,9 +64,7 @@
                         information.</note>
                      <note>سورة یس (Surah 36) on fol. 1a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -81,9 +81,7 @@
                         information.</note>
                      <note>شرح دعاء عهد on fol. 15a (see No. 19 in 2261).</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -100,9 +98,7 @@
                         information.</note>
                      <note>دعاء عهدنامهٔ مبارك on fol. 20b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -119,9 +115,7 @@
                         information.</note>
                      <note>شرح دعاء خضر الياس on fol. 23a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -138,9 +132,7 @@
                         information.</note>
                      <note>دعاء خضر الياس on fol. 31a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -157,9 +149,7 @@
                         information.</note>
                      <note>شرح دعاء ابا فردا on fol. 39a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -177,9 +167,7 @@
                         information.</note>
                      <note>دعاء ابا فردا on fol. 44a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -198,9 +186,7 @@
                         information.</note>
                      <note>شرح مهرى يوصف (= یوسف) on fol. 47a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -219,9 +205,7 @@
                         information.</note>
                      <note>مهرى يوصف (= یوسف) on fol. 49b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -238,9 +222,7 @@
                         information.</note>
                      <note>مهری (= مهر) آدم پیغمبر on fol. 50a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -258,9 +240,7 @@
                         information.</note>
                      <note>مهری (= مهر) آدم on fol. 52a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -278,9 +258,7 @@
                         information.</note>
                      <note>شرح دعاء حسن و حسین on fol. 52b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -298,9 +276,7 @@
                         information.</note>
                      <note>دعاء حسن و حسین on fol. 57a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -317,9 +293,7 @@
                         information.</note>
                      <note>شرح دعاء مشمخ on fol. 60a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -336,9 +310,7 @@
                         information.</note>
                      <note>مشمخ المبارك on fol. 75b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -355,9 +327,7 @@
                         information.</note>
                      <note>دعاء عقدة اللسان on fol. 77b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -374,9 +344,7 @@
                         information.</note>
                      <note>شرح مهر خضر الياس on fol. 81a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -393,9 +361,7 @@
                         information.</note>
                      <note>مهر خضر پیغمبر on fol. 82a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -417,9 +383,7 @@
                      <note>مُهرى شرح حضرت محمّد المصطفا (= شرح مُهر حضرت محمّد المصطفا) on fol.
                         82b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -437,9 +401,7 @@
                         information.</note>
                      <note>مُهرى (= مهر) حضرت محمّد المصطفا on fol. 84b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -459,9 +421,7 @@
                         information.</note>
                      <note>دعا شرح جن (= شرح دعا جن) on fol. 85a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -480,9 +440,7 @@
                         information.</note>
                      <note>باب مهری (= مهر) نبوّة محمد on fol. 89a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -499,9 +457,7 @@
                         information.</note>
                      <note>شرح دعاء عقدة اللسان on fol. 90b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -518,9 +474,7 @@
                         information.</note>
                      <note>دعاء عقدة اللسان on fol. 93b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -539,9 +493,7 @@
                         information.</note>
                      <note>شرح مهری (= مهر) نبوّة محمد المصطفا on fol. 97b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -560,9 +512,7 @@
                         information.</note>
                      <note>مهری (= مهر) نبوّة رسول on fol. 99b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -581,9 +531,7 @@
                         information.</note>
                      <note>دعا حضرت رسول on fol. 102a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -601,9 +549,7 @@
                         information.</note>
                      <note>باب دعا طاعون on fol. 104a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -622,9 +568,7 @@
                         information.</note>
                      <note>دعا طاعون on fol. 105a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -641,9 +585,7 @@
                      <note>On ff. 107a-122b a series of short prayers for special occasions is
                         added, but this is incomplete at the end.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (224) 2262.</ref></bibl>
@@ -681,8 +623,7 @@
                      </recordHist>
                      <availability status="restricted">
                         <p>Entry to read in the Library is permitted only on presentation of a valid
-                           reader's card (for admissions procedures contact <ref
-                              target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                           reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                               Admissions</ref>).</p>
                      </availability>
                   </adminInfo>
@@ -705,8 +646,7 @@
             <keywords scheme="#LCSH">
                <list>
                   <item>
-                     <term key="subject_sh85106139"
-                        target="http://id.loc.gov/authorities/sh85106139#concept">Prayers</term>
+                     <term key="subject_sh85106139" target="http://id.loc.gov/authorities/sh85106139#concept">Prayers</term>
                   </item>
                </list>
             </keywords>
@@ -714,25 +654,17 @@
       </profileDesc>
       <revisionDesc>
          <change when="2018-06-08">
-            <persName>Andrew Morrison</persName> Updated key attributes using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl"
-               >update-keys.xsl</ref>
+            <persName>Andrew Morrison</persName> Updated key attributes using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl">update-keys.xsl</ref>
          </change>
          <change when="2018-03-15" xml:id="add-summary">
-            <persName>Andrew Morrison</persName> Added summary using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl"
-               >add-summaries.xsl</ref>
+            <persName>Andrew Morrison</persName> Added summary using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl">add-summaries.xsl</ref>
          </change>
          <change when="2018-03-02" xml:id="fix-dates">
             <persName>Andrew Morrison</persName> Removed origDate tags around something which is not
-            a date using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl"
-               >fix-dates.xsl</ref>
+            a date using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl">fix-dates.xsl</ref>
          </change>
          <change when="2017-11-07">
-            <persName>James Cummings</persName> Up-converted the markup using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl"
-               >https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl">https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
          </change>
          <change when="2009-05-14">created this file</change>
       </revisionDesc>

--- a/collections/oxford university/MS_Bodl_Or_179.xml
+++ b/collections/oxford university/MS_Bodl_Or_179.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10545">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10545">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,9 +58,7 @@
                         from No. 2260, 33, and No. 2261, 13; but comp. Nos. 2260, 15, and
                         2264, 7). This is incomplete both at beginning and end.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_181.xml
+++ b/collections/oxford university/MS_Bodl_Or_181.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10547">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10547">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -59,9 +62,7 @@
                         Serrinii donatione,' and presented it afterwards, 1695, to Henry
                         Chr. de Hennin.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_185.xml
+++ b/collections/oxford university/MS_Bodl_Or_185.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23152">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23152">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +76,7 @@
                            Or. 85</ref>. </filiation>
                      
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775161">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=25">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1186 § (55) 2093.</ref></bibl>
@@ -126,7 +129,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Bodl_Or_191.xml
+++ b/collections/oxford university/MS_Bodl_Or_191.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23182">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23182">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -73,9 +71,7 @@
                             <title key="work_6444" xml:lang="ota">حکایات اسه‌پوس</title>
                             <incipit>اسه‌پوس کوتاهیّه سنجاغنه تابع اموریه نام موضعه طوغمش ایدی و بر کمسه‌نڭ قولی ایدی</incipit>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1194 § (71) 2109.</ref></bibl>
@@ -109,8 +105,7 @@
                         
                         <origin>
                             Place of origin unknown. 
-                            <origDate notAfter="1752-04-22" calendar="#Gregorian"
-                                >Date of origin unknown, but written some time before its donation to the Bodleian on 22 April 1752.</origDate>
+                            <origDate notAfter="1752-04-22" calendar="#Gregorian">Date of origin unknown, but written some time before its donation to the Bodleian on 22 April 1752.</origDate>
                         </origin>
                         
                         <provenance>Formerly of the collection of <persName key="person_f7929">William Wood</persName>.</provenance>
@@ -124,9 +119,7 @@
                         
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930.</ref>
@@ -134,8 +127,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of a valid
-                                    reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                                    reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                                         Admissions</ref>). Contact
                                     <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for
                                     further information on the availability of this manuscript</p>

--- a/collections/oxford university/MS_Bodl_Or_192.xml
+++ b/collections/oxford university/MS_Bodl_Or_192.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23156">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23156">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -68,7 +71,7 @@
                      <title key="work_23249" xml:lang="ota-Latn-x-lc">Türkçe tekellümāt</title>
                      <title key="work_23249" xml:lang="ota">ترکچه تکلمات</title>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775195">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1254 § (205) 2243.</ref></bibl>
@@ -96,7 +99,7 @@
                            Or. 85</ref>. </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775162">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=26">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1187 § (59) 2097.</ref></bibl>
@@ -145,7 +148,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Bodl_Or_193.xml
+++ b/collections/oxford university/MS_Bodl_Or_193.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23278">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_193</idno>
@@ -54,9 +55,7 @@
                                 Turkish translation of Tabari. The whole copy is without the
                                 slightest value.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,9 +88,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,9 +96,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_197.xml
+++ b/collections/oxford university/MS_Bodl_Or_197.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23126">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23126">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -69,7 +72,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2063</ref></bibl>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2063</ref></bibl>
                                    <bibl> <ref target="https://www.proquest.com/books/capitulations-articles-peace-between-majesty-king/docview/2240862463/se-2">(anonymous). (1679). The Capitulations and Articles of
                                         Peace between the Majesty of the King of Great Britain,
                                         France, and Ireland, etc. and the Sultan of the Ottoman

--- a/collections/oxford university/MS_Bodl_Or_20.xml
+++ b/collections/oxford university/MS_Bodl_Or_20.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23279">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_20</idno>
@@ -52,9 +53,7 @@
                                 more information.</note>
                             <note>Several pages left blank.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -87,9 +86,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,9 +94,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_201.xml
+++ b/collections/oxford university/MS_Bodl_Or_201.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10553">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10553">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -51,9 +54,7 @@
                                 more information.</note>
                             <note>شرح دعاء دولت on fol. 1b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -74,9 +75,7 @@
                                 fol. 13b: اللهم يا الله يا رب يا رحمن يا رحيم يا مالك یا قدوس
                                 الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,9 +93,7 @@
                                 more information.</note>
                             <note>شرح دعاء جبرائيل on fol. 27b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,9 +112,7 @@
                                 more information.</note>
                             <note>دعاء جبرائيل on fol. 36a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -135,9 +130,7 @@
                                 more information.</note>
                             <note>شرح دعاء رسول on fol. 35a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -156,9 +149,7 @@
                                 more information.</note>
                             <note>دعاء رسول on fol. 36a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -176,9 +167,7 @@
                                 more information.</note>
                             <note>دعاء ایمان رسول on fol. 37b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -196,9 +185,7 @@
                                 more information.</note>
                             <note>Another شرح دعاء رسول on fol 38a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -219,9 +206,7 @@
                                 more information.</note>
                             <note>Another دعاء رسول on fol. 40a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -239,9 +224,7 @@
                                 more information.</note>
                             <note>شرح دعاء مقبول on fol. 41a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -259,9 +242,7 @@
                                 more information.</note>
                             <note>دعاء مقبول on fol. 41b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -279,9 +260,7 @@
                                 more information.</note>
                             <note>شرح دعاء قبر on on fol. 42a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -299,9 +278,7 @@
                                 more information.</note>
                             <note>دعاء قبر مجرّب on fol 42b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -319,9 +296,7 @@
                                 more information.</note>
                             <note>شرح دعاء شریف on fol. 44a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -339,9 +314,7 @@
                                 more information.</note>
                             <note>دعاء شریف on fol. 45a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -359,9 +332,7 @@
                                 more information.</note>
                             <note>شرح دعاء قدح on fol. 47a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -379,9 +350,7 @@
                                 more information.</note>
                             <note>دعاء قدح on fol. 53b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -401,9 +370,7 @@
                                 more information.</note>
                             <note>سورة يس (Sūrah 36) on fol. 65b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -421,9 +388,7 @@
                                 more information.</note>
                             <note>شرح اسم اعظم on fol. 75b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -441,9 +406,7 @@
                                 more information.</note>
                             <note>دعاء اسم اعظم on fol.83a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -460,9 +423,7 @@
                                 more information.</note>
                             <note>Prayers without a heading.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -480,9 +441,7 @@
                                 more information.</note>
                             <note>شرح هیکل بازوبند on fol. 96a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -500,9 +459,7 @@
                                 more information.</note>
                             <note>الهيكل بازوبند on on fol. 98a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -520,9 +477,7 @@
                                 more information.</note>
                             <note>شرح آیات سبع on fol. 99a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -540,9 +495,7 @@
                                 more information.</note>
                             <note>دعاء سبع آیات on fol. 100a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -560,9 +513,7 @@
                                 more information.</note>
                             <note>شرح دعاء پیغمبر on fol. 103a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -580,9 +531,7 @@
                                 more information.</note>
                             <note>دعاء حضرت پیغمبر on fol. 104b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -600,9 +549,7 @@
                                 more information.</note>
                             <note>شرح دعاء صلوات on fol. 105b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -613,16 +560,13 @@
                         <msItem xml:id="MS_Bodl_Or_201-item29" n="29">
                             <title key="work_23587">Duʿā'-ı ṣalavāt</title>
                             <title xml:lang="ota" key="work_23587">دعاء صلوات</title>
-                            <note>NOTE: This record has been automatically gene<author
-                                    key="person_f407">anonymous</author>rated with minimal
+                            <note>NOTE: This record has been automatically gene<author key="person_f407">anonymous</author>rated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
                                 more information.</note>
                             <note>دعاء صلوات on fol. 111b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -640,9 +584,7 @@
                                 more information.</note>
                             <note>شرح جميل on fol. 121a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -660,9 +602,7 @@
                                 more information.</note>
                             <note>دعاء جميل on fol. 125b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -680,9 +620,7 @@
                                 more information.</note>
                             <note>شرح اسم اعظم (different from No. 19) on fol. 129b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -700,9 +638,7 @@
                                 more information.</note>
                             <note>دعاء اسم اعظم (also different from no. 20) on fol. 141a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -721,9 +657,7 @@
                             <note>شرح دعاء دولت (slightly different in wording from No. 1) on fol.
                                 151b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -742,9 +676,7 @@
                             <note>دعاء دولت (heading omitted here, but supplied by comparison with
                                 Thurston 39, fol. 44a, see the next copy) on fol. 172a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -764,9 +696,7 @@
                                 fol. 212a الهيكل الخامس, on fol. 218a الهيكل السادس, and on fol.
                                 225b الهيكل السابع.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -786,9 +716,7 @@
                                 more information.</note>
                             <note>شرح دعاء سرح (= سرخ) باد on fol. 228b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -811,9 +739,7 @@
                                 Flügel iii. p. 151 sq.; Fleischer, Cod. Lips., pp. 412 sq. and 446
                                 sq., etc. etc.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_226.xml
+++ b/collections/oxford university/MS_Bodl_Or_226.xml
@@ -1,4 +1,6 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10558">
    <teiHeader>
       <fileDesc>
@@ -59,9 +61,7 @@
                      <note>Parts of Sūrah 6, beginning, on fol. 4a: الحمد الله الذي خلق السموات
                         الخ.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -80,9 +80,7 @@
                         information.</note>
                      <note>دعاء رسل الله on fol. 9b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -98,9 +96,7 @@
                         information.</note>
                      <note>دعاء آخر on fol. 13b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -118,9 +114,7 @@
                         information.</note>
                      <note>Sūrah 36, on fol. 14b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -140,9 +134,7 @@
                      <note>Sūrah 48, beginning, on fol. 25b: إنَّا فَتَحْنَا لك فَتحًا
                         مُبِینًا.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -161,9 +153,7 @@
                         information.</note>
                      <note>Sūrah 56, beginning, on fol. 34a: إذَا وَقَعَتِ اَلْوَاقِعَةُ.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -181,9 +171,7 @@
                      <note>An Arabic prayer, on fol. 40a, beginning: يا جميل يا الله يا قريب يا الله
                         الخ, followed by short pieces of the Qur'ān, etc.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -200,9 +188,7 @@
                      <note>دعاء كفن in Arabic and Turkish, with other short pieces, on fol.
                         51a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -218,9 +204,7 @@
                         information.</note>
                      <note>شرح دعاء قدح on fol. 63b (comp. Nos. 2260, 16, and 2261, 3).</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -236,9 +220,7 @@
                         information.</note>
                      <note>دعاء قدح on fol. 76b (comp. Nos. 2260, 17, No. 2261, 16).</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -254,9 +236,7 @@
                         information.</note>
                      <note>شرح دعاء مرجان on fol. 82b (comp. No. 2261, 16)</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -274,9 +254,7 @@
                      <note>دعاء مرجان on fol. 90b (comp. No. 2261, 17), followed by other prayers
                         and pieces of the Qur'ān, in Turkish and Arabic.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -292,9 +270,7 @@
                         information.</note>
                      <note>شرح دعاء جعفر الیاس in Turkish, on fol. 121b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -310,9 +286,7 @@
                         information.</note>
                      <note>دعاء جعفر الیاس on fol. 131b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -329,9 +303,7 @@
                         information.</note>
                      <note>فال قرآن in Turkish, on fol. 134b. 145b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -347,9 +319,7 @@
                         information.</note>
                      <note>تکرار الحروف in Turkish, on fol 142b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -365,9 +335,7 @@
                         information.</note>
                      <note>سكرنامه اندام انسان in Turkish on fol. 145b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -382,9 +350,7 @@
                         information.</note>
                      <note>Arabic prayer, on fol. 154a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -403,9 +369,7 @@
                         fol. 155 sq. pieces of the Qur'ān, etc., beginning with the first verse of
                         Sūrah 6 (see No. 1).</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (225) 2263.</ref></bibl>
@@ -443,8 +407,7 @@
                      </recordHist>
                      <availability status="restricted">
                         <p>Entry to read in the Library is permitted only on presentation of a valid
-                           reader's card (for admissions procedures contact <ref
-                              target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                           reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                               Admissions</ref>).</p>
                      </availability>
                   </adminInfo>
@@ -467,8 +430,7 @@
             <keywords scheme="#LCSH">
                <list>
                   <item>
-                     <term key="subject_sh85068403"
-                        target="http://id.loc.gov/authorities/sh85068403#concept">Islamic
+                     <term key="subject_sh85068403" target="http://id.loc.gov/authorities/sh85068403#concept">Islamic
                         prayers</term>
                   </item>
                </list>
@@ -477,25 +439,17 @@
       </profileDesc>
       <revisionDesc>
          <change when="2018-06-08">
-            <persName>Andrew Morrison</persName> Updated key attributes using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl"
-               >update-keys.xsl</ref>
+            <persName>Andrew Morrison</persName> Updated key attributes using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl">update-keys.xsl</ref>
          </change>
          <change when="2018-03-15" xml:id="add-summary">
-            <persName>Andrew Morrison</persName> Added summary using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl"
-               >add-summaries.xsl</ref>
+            <persName>Andrew Morrison</persName> Added summary using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl">add-summaries.xsl</ref>
          </change>
          <change when="2018-03-02" xml:id="fix-dates">
             <persName>Andrew Morrison</persName> Removed origDate tags around something which is not
-            a date using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl"
-               >fix-dates.xsl</ref>
+            a date using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl">fix-dates.xsl</ref>
          </change>
          <change when="2017-11-07">
-            <persName>James Cummings</persName> Up-converted the markup using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl"
-               >https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl">https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
          </change>
          <change when="2009-05-14">created this file</change>
       </revisionDesc>

--- a/collections/oxford university/MS_Bodl_Or_234.xml
+++ b/collections/oxford university/MS_Bodl_Or_234.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23128">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23128">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -51,7 +54,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2065</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2065</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Bodl_Or_255.xml
+++ b/collections/oxford university/MS_Bodl_Or_255.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23254">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_255</idno>
@@ -57,9 +58,7 @@
                                 (see Nos. 2202-2205 below); two dates appear, viz. AH 989=AD 1581,
                                 on fol. 7b, and AH 1045=AD 1635/1636.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -88,9 +87,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -98,9 +95,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_256.xml
+++ b/collections/oxford university/MS_Bodl_Or_256.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23125">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23125">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -66,7 +69,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2062</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2062</ref>
                                     <ref target="https://www.proquest.com/books/capitulations-articles-peace-between-majesty-king/docview/2240862463/se-2">(anonymous). (1679). The Capitulations and Articles of
                                         Peace between the Majesty of the King of Great Britain,
                                         France, and Ireland, etc. and the Sultan of the Ottoman

--- a/collections/oxford university/MS_Bodl_Or_276.xml
+++ b/collections/oxford university/MS_Bodl_Or_276.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23131">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23131">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -75,7 +78,7 @@
                                 حکمته و یغفر الله لنا و الجمیع المسلمین بآثار قدرته </incipit>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775154">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=18">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_320.xml
+++ b/collections/oxford university/MS_Bodl_Or_320.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23282">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_320</idno>
@@ -65,9 +66,7 @@
                                 467a (p. 923); to the Philippians, on fol. 477b (p. 944); to the
                                 Colossians, on fol. 485b (p. 960).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -79,8 +78,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>489 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>489 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="2" n="mistara">2 columns of varying number of lines
@@ -94,9 +92,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -104,9 +100,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_327.xml
+++ b/collections/oxford university/MS_Bodl_Or_327.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23283">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_327</idno>
@@ -52,9 +53,7 @@
                                 15-34 exercises in the declensions, and on ff. 34b-88 exercises in
                                 the conjugations, both simple and compound verbal forms.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -87,9 +86,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,9 +94,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_368.xml
+++ b/collections/oxford university/MS_Bodl_Or_368.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23284">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_368</idno>
@@ -56,9 +57,7 @@
                                 the same Tollius presented Henr. Chr. de Hennin with it in 1695; see
                                 above, No. 2267 and the immediately following copy, No. 2297.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -70,8 +69,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>46 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>46 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara">1 column of varying number of lines
@@ -91,9 +89,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,9 +97,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_379.xml
+++ b/collections/oxford university/MS_Bodl_Or_379.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23285">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_379</idno>
@@ -51,9 +52,7 @@
                             <note>A list of Turkish words, explained in Greek and Latin, on ff.
                                 1-22.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -69,9 +68,7 @@
                                 more information.</note>
                             <note>Turkish phrases, with Latin paraphrase, on ff. 23-66a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -81,8 +78,7 @@
                         </msItem>
                         <msItem xml:id="MS_Bodl_Or_379-item3" n="3">
                             <title type="desc">A saying of Muḥammed and a few lines</title>
-                            <author key="person_36927901"><persName xml:lang="ota-Latn-x-lc"
-                                >Leusden, Johannes, 1624-1699</persName></author>
+                            <author key="person_36927901"><persName xml:lang="ota-Latn-x-lc">Leusden, Johannes, 1624-1699</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -92,9 +88,7 @@
                                 greatest Hebrew scholars in the seventeenth century, born in
                                 Utrecht, 1624, died 1699.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -104,8 +98,7 @@
                         </msItem>
                         <msItem xml:id="MS_Bodl_Or_379-item4" n="4">
                             <title key="work_23604">Excerpta ex Codice Leusdeniano</title>
-                            <author key="person_36927901"><persName xml:lang="ota-Latn-x-lc"
-                                >Leusden, Johannes, 1624-1699</persName></author>
+                            <author key="person_36927901"><persName xml:lang="ota-Latn-x-lc">Leusden, Johannes, 1624-1699</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -113,9 +106,7 @@
                             <note>Excerpta ex Codice Leusdeniano, ff. 12; one of the larger extracts
                                 deals with the, or the prophet's ascension to heaven.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -148,9 +139,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -158,9 +147,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_38.xml
+++ b/collections/oxford university/MS_Bodl_Or_38.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23286">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_38</idno>
@@ -55,9 +56,7 @@
                                 first of Receb and going down to the eighteenth of Ramażān, in which
                                 it breaks off, in consequence of a lacuna after fol. 11.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,9 +82,7 @@
                                 fol. 16a, etc. Beginning: بسم الله الرّحمن الرّحيم ودخى رسول حضرت
                                 عليه السلام ایتدى هركم رجبك اول كجيسي الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=64">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,8 +94,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>22 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>22 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara" ruledLines="16">1 column of 16 lines
@@ -116,9 +112,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -126,9 +120,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_394.xml
+++ b/collections/oxford university/MS_Bodl_Or_394.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23184">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23184">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -61,8 +58,7 @@
                     <msContents>
 
                         <summary>One copy of <persName role="author" xml:lang="chg-Latn-x">Mawlānā
-                                Luṭfī</persName>'s Chaghatay <title key="" xml:lang="chg-Latn-x-lc"
-                                >Gul u Nawrūz</title>, apparently missing the first six
+                                Luṭfī</persName>'s Chaghatay <title key="" xml:lang="chg-Latn-x-lc">Gul u Nawrūz</title>, apparently missing the first six
                             chapters.</summary>
                         <textLang mainLang="chg">Chaghatay</textLang>
 
@@ -75,10 +71,8 @@
                             <title key="work_23357" xml:lang="chg">گل و نوروز</title>
                             <rubric>گل و نوروز کتابی‌نینك اوّلی</rubric>
                             <note>A note on <locus>folio 124b</locus> states that the work was
-                                originally written on <date notBefore="1411" notAfter="1412"
-                                    calendar="#Hijri-qamari">تأریخ سکز یوز اون تورت = 814 AH</date>
-                                (i.e. in <date notBefore="1411" notAfter="1412"
-                                    calendar="#Gregorian">1411/2 CE</date>) and dedicated to
+                                originally written on <date notBefore="1411" notAfter="1412" calendar="#Hijri-qamari">تأریخ سکز یوز اون تورت = 814 AH</date>
+                                (i.e. in <date notBefore="1411" notAfter="1412" calendar="#Gregorian">1411/2 CE</date>) and dedicated to
                                 <persName key="person_f8473" role="dte"><persName>Sikandar Sulṭān</persName>
                                     <persName>سکندر سلطان</persName></persName>, better known as
                                 <persName role="dte" key="person_f8473"><persName>Iskandar Mīrzā</persName>
@@ -86,9 +80,7 @@
                                     <persName key="person_63984707">Amīr Temür</persName> and ruler
                                 of much of western Iran in the early 1400s CE. </note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -142,9 +134,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -153,9 +143,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -232,10 +220,8 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh00007420.html"
-                            ><term key="subject_sh00007420">Sufi poetry, Chagatai</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh92003639.html"
-                            ><term key="subject_sh92003639"> 	Nawrūz (Festival)</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh00007420.html"><term key="subject_sh00007420">Sufi poetry, Chagatai</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh92003639.html"><term key="subject_sh92003639"> 	Nawrūz (Festival)</term></ref></item>
                     </list>
                 </keywords>
             </textClass>

--- a/collections/oxford university/MS_Bodl_Or_399.xml
+++ b/collections/oxford university/MS_Bodl_Or_399.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23220">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_399</idno>
@@ -74,9 +75,7 @@
                                 شعرا, is not quite correct, as only a limited number of poems found
                                 here are ġazels.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -102,8 +101,7 @@
                             <handNote scope="major" script="nasta_liq"><desc>Script:
                                 Nestaʿlīḳ</desc></handNote>
                         </handDesc>
-                        <decoDesc><decoNote type="headpiece"
-                                >illuminated headpiece</decoNote></decoDesc>
+                        <decoDesc><decoNote type="headpiece">illuminated headpiece</decoNote></decoDesc>
                         
                     </physDesc>
                     <history>
@@ -112,9 +110,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -122,9 +118,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_4.xml
+++ b/collections/oxford university/MS_Bodl_Or_4.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23210">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_4</idno>
@@ -51,9 +52,7 @@
                             <note>Hymns, on ff. 1b-9b, 10b-19b, 20b-22a, 47b49b, 52-53b, 58a and b,
                                 and 61a-63b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -73,9 +72,7 @@
                                 Dichtkunst, iii. p. 611), on ff. 25-32, 41, 44a and b, 51b, 56b,
                                 57a, and 60a and b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -92,9 +89,7 @@
                             <note>Popular songs, (see Hammer, etc. i. p. 18), on ff. 32b-41a, 41b
                                 and 42, 45-47a, 49b-51a, 53b56, 56b, 57b, and 59a and b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -111,9 +106,7 @@
                             <note>Wheels of poetry or praise, i. e. encomiastic enumerations of
                                 famous names (see Hammer, etc. iii. p. 603), on ff. 428-44.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -132,9 +125,7 @@
                                 No. 2144, and W. Pertsch, p. 37, note 2), on ff. 19b, 20a, and
                                 22b-25b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -152,9 +143,7 @@
                                 first hymn begins, on fol. 1b, thus: اول اولو مولائی سوسن سَوْمَكه
                                 یار استين اسمنی وبرد ایلسون دایما کار اشتین.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -187,9 +176,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -197,9 +184,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_403.xml
+++ b/collections/oxford university/MS_Bodl_Or_403.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23183">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23183">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -69,9 +67,7 @@
                             <title key="work_23359" xml:lang="ota">حکایات</title>
                             <incipit>حکایت اولنور که بر پادشاه بر اسیری اولدرمکلکه امر ایلدی</incipit>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1194 § (72) 2110.</ref></bibl>
@@ -103,8 +99,7 @@
                         
                         <origin>
                             Place of origin unknown. 
-                            <origDate notAfter="1822" calendar="#Gregorian"
-                                >Date of origin unknown, but written some time before its donation to the Bodleian no later than 1822.</origDate>
+                            <origDate notAfter="1822" calendar="#Gregorian">Date of origin unknown, but written some time before its donation to the Bodleian no later than 1822.</origDate>
                         </origin>
                         
                         <acquisition>Acquired by the Bodleian <date from="1695" to="1822" calendar="#Gregorian">some time between 1695-1822</date>.</acquisition>
@@ -115,9 +110,7 @@
                         
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930.</ref>
@@ -125,8 +118,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of a valid
-                                    reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                                    reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                                         Admissions</ref>). Contact
                                     <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for
                                     further information on the availability of this manuscript</p>

--- a/collections/oxford university/MS_Bodl_Or_41.xml
+++ b/collections/oxford university/MS_Bodl_Or_41.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23181">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23181">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -63,8 +60,7 @@
 
                     <msContents>
 
-                        <summary>One small fragment of an anonymous Turkish <title
-                            xml:lang="ota-Latn-x-lc">Ḥamzanāme</title>, which gives a legendary account of the companion of the Prophet, <persName key="person_45933621" role="subject">Ḥamzah ibn ʻAbd al-Muṭṭalib</persName>.</summary>
+                        <summary>One small fragment of an anonymous Turkish <title xml:lang="ota-Latn-x-lc">Ḥamzanāme</title>, which gives a legendary account of the companion of the Prophet, <persName key="person_45933621" role="subject">Ḥamzah ibn ʻAbd al-Muṭṭalib</persName>.</summary>
                         <textLang mainLang="ota">Ottoman Turkish</textLang>
 
                         <msItem xml:id="MS_Bodl_Or_41-item1" n="1">
@@ -72,9 +68,7 @@
                             <title key="work_23354" xml:lang="ota-Latn-x-lc">Ḥamzanāme</title>
                             <title key="work_23354" xml:lang="ota">حمزه‌نامه</title>
                             <incipit>قلدلر امیر حمزه دربند اغزنده قوندی عیشه مشغول اولدی</incipit>
-                            <note><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                    >Ethé (1930:§ (70) 2108)</ref> notes that the leaves of this
+                            <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé (1930:§ (70) 2108)</ref> notes that the leaves of this
                                 manuscript have been rearranged out of order, and that the proper
                                 order of the folios is <locusGrp>
                                     <locus from="1" to="1">1, </locus>
@@ -91,9 +85,7 @@
                                 </locusGrp> with a major lacuna in the text after <locus>folio
                                     3</locus>.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -139,9 +131,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -150,9 +140,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -229,10 +217,8 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85088280.html"
-                            ><term key="subject_sh85088280">Muḥammad, Prophet, -632--Companions</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85075790.html"
-                            ><term key="subject_sh85075790">Islamic legends</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85088280.html"><term key="subject_sh85088280">Muḥammad, Prophet, -632--Companions</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85075790.html"><term key="subject_sh85075790">Islamic legends</term></ref></item>
                     </list>
                 </keywords>
             </textClass>

--- a/collections/oxford university/MS_Bodl_Or_430.xml
+++ b/collections/oxford university/MS_Bodl_Or_430.xml
@@ -1,4 +1,6 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4181">
    <teiHeader>
       <fileDesc>
@@ -51,17 +53,14 @@
                      <title key="work_4945">An album of Ottoman people and monuments</title>
                      <listBibl>
                         <bibl>
-                           <ref
-                              target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775203"
-                           >Ethé,
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=67">Ethé,
                               Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                               Hindûstânî, Pushtû and Additional Persian Manuscripts</title>. Oxford:
                               Clarendon Press. 1930. col. 1270 § (247) 2285.</ref>
                         </bibl>
                         <bibl>Ethé 2285</bibl>
-                        <bibl>An explanation of some of the plates can be found in <ref
-                              target="https://hdl.handle.net/2027/mdp.39015056233813"> Skilliter,
+                        <bibl>An explanation of some of the plates can be found in <ref target="https://hdl.handle.net/2027/mdp.39015056233813"> Skilliter,
                            Susan. (1977). Life in Istanbul, 1588: Scenes from a traveller's picture
                            book. Oxford: Bodleian Library.</ref></bibl>
                      </listBibl>
@@ -81,7 +80,7 @@
                      </supportDesc>
                      <layoutDesc>
                         <layout columns="4">
-                           <dimensions type="line-height" unit="mm" />
+                           <dimensions type="line-height" unit="mm"/>
                         </layout>
                      </layoutDesc>
                   </objectDesc>
@@ -107,8 +106,7 @@
                            research, the importance of this item to that research, and the resources
                            you have already consulted. Your application will then be considered by
                            our curatorial staff. Entry to read in the Library is permitted only on
-                           presentation of a valid reader's card (for admissions procedures contact <ref
-                              target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                           presentation of a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                            Admissions</ref>).</p>
                      </availability>
                   </adminInfo>
@@ -187,8 +185,7 @@
             <keywords scheme="#LCSH">
                <list>
                   <item>
-                     <term key="subject_sh86005070"
-                        target="http://id.loc.gov/authorities/subjects/sh86005070">Art,
+                     <term key="subject_sh86005070" target="http://id.loc.gov/authorities/subjects/sh86005070">Art,
                         Ottoman</term>
                   </item>
                </list>
@@ -197,24 +194,20 @@
       </profileDesc>
       <revisionDesc>
          <change when="2018-06-08">
-            <persName>Andrew Morrison</persName> Updated key attributes using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl">
+            <persName>Andrew Morrison</persName> Updated key attributes using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl">
             update-keys.xsl</ref>
          </change>
          <change when="2018-03-15" xml:id="add-summary">
-            <persName>Andrew Morrison</persName> Added summary using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl">
+            <persName>Andrew Morrison</persName> Added summary using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl">
             add-summaries.xsl</ref>
          </change>
          <change when="2018-03-02" xml:id="fix-dates">
             <persName>Andrew Morrison</persName> Removed origDate tags around something which is not
-            a date using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl">
+            a date using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl">
             fix-dates.xsl</ref>
          </change>
          <change when="2017-11-07">
-            <persName>James Cummings</persName> Up-converted the markup using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl">
             https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
          </change>
          <change when="2012-02-06">
@@ -222,10 +215,10 @@
       </revisionDesc>
    </teiHeader>
    <facsimile>
-      <graphic url="folio1r.png" />
-      <graphic url="folio1v.png" />
-      <graphic url="folio2r.png" />
-      <graphic url="folio2v.png" />
+      <graphic url="folio1r.png"/>
+      <graphic url="folio1v.png"/>
+      <graphic url="folio2r.png"/>
+      <graphic url="folio2v.png"/>
    </facsimile>
    <text>
       <body>

--- a/collections/oxford university/MS_Bodl_Or_471.xml
+++ b/collections/oxford university/MS_Bodl_Or_471.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23241">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_471</idno>
@@ -61,9 +62,7 @@
                                 عزتلو و سعادتلو بنده لرينه مرحمتلو سلطانم حضرتلرینگ مبارك خاکهای
                                 الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=47">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -91,16 +90,12 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" notBefore="1694" notAfter="1695"
-                                >1106</origDate><origDate calendar="#Gregorian" notBefore="1694"
-                                notAfter="1695">1694/1695</origDate></origin>
+                        <origin><origDate calendar="#Hijri-qamari" notBefore="1694" notAfter="1695">1106</origDate><origDate calendar="#Gregorian" notBefore="1694" notAfter="1695">1694/1695</origDate></origin>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,9 +103,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_477.xml
+++ b/collections/oxford university/MS_Bodl_Or_477.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23155">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23155">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -86,7 +89,7 @@
                         1404-1451</persName>, and copied and circulated widely during his
                         reign.</note>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775162">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=26">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1187-1188 § (61)
@@ -136,7 +139,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Bodl_Or_481.xml
+++ b/collections/oxford university/MS_Bodl_Or_481.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23229">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_481</idno>
@@ -77,9 +78,7 @@
                                 written on the margin of fol. 1b and part of fol. 2a, and some
                                 astronomical tables appear on the fly-leaf and on fol. 1a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=45">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -112,9 +111,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -122,9 +119,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_515-518.xml
+++ b/collections/oxford university/MS_Bodl_Or_515-518.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23190">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23190">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -79,8 +76,7 @@
                     <msContents>
 
                         <summary>One copy of <persName key="person_47178052" role="author">Hamdullah
-                                Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc"
-                                >Yūsuf ü Züleyḫā</title> in Ottoman Turkish.</summary>
+                                Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title> in Ottoman Turkish.</summary>
                         <textLang mainLang="ota">Ottoman Turkish</textLang>
 
                         <msItem xml:id="MS_Bodl_Or_515-518-item1" n="1">
@@ -97,28 +93,19 @@
                             <incipit>ذِکْر اُلِنْمَاسَه اَوَّل اِسْمُ اللَهْ هَرْ نَه بَشْلَنْسَه
                                 اَخِرْ اُولَه تَبَاهْ</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1202 § (90) 2128.</ref></bibl>
                             </listBibl>
-                            <note>A complete copy of <persName key="person_47178052" role="author"
-                                    >Ḥamdüllāh Ḥamdī</persName>'s <title key=""
-                                    xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title> in two volumes,
+                            <note>A complete copy of <persName key="person_47178052" role="author">Ḥamdüllāh Ḥamdī</persName>'s <title key="" xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title> in two volumes,
                                 modeled on the <title key="work_20147">Yūsuf va-Zulaykhā</title> of
                                     <persName key="person_90042997" role="ant">Jāmī</persName> and
-                                completed in <date notBefore="1491-11-04" notAfter="1492-10-22"
-                                    calendar="#Gregorian">897 AH</date> (<date
-                                    notBefore="1491-11-04" notAfter="1492-10-22"
-                                    calendar="#Gregorian">between 4 November 1491 and 22 October
+                                completed in <date notBefore="1491-11-04" notAfter="1492-10-22" calendar="#Gregorian">897 AH</date> (<date notBefore="1491-11-04" notAfter="1492-10-22" calendar="#Gregorian">between 4 November 1491 and 22 October
                                     1492 CE</date>).</note>
-                            <filiation>At least one other complete (<ref
-                                    target="https://www.fihrist.org.uk/catalog/manuscript_23189">MS.
-                                    Marsh 633</ref>) and one partial (<ref
-                                    target="https://www.fihrist.org.uk/catalog/manuscript_23191">MS.
+                            <filiation>At least one other complete (<ref target="https://www.fihrist.org.uk/catalog/manuscript_23189">MS.
+                                    Marsh 633</ref>) and one partial (<ref target="https://www.fihrist.org.uk/catalog/manuscript_23191">MS.
                                     Laud Or. 87</ref>) copy of the same text exist in the Bodleian
                                 Libraries.</filiation>
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
@@ -150,9 +137,7 @@
                                 </foliation>
 
                                 <collation>
-                                    <p><ref
-                                            target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                            >Ethé (1930. col. 1202 § 2128)</ref> notes that the
+                                    <p><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé (1930. col. 1202 § 2128)</ref> notes that the
                                             <locus from="73" to="92">folios between 73 and
                                             92</locus> in volume 1 are out of order; the correct
                                         order is <locusGrp>
@@ -173,8 +158,7 @@
                         </objectDesc>
 
                         <handDesc>
-                            <handNote scope="major" script="nasta_liq"
-                                medium="blackink redink blueink">Nasta‘līḳ in black ink with red and
+                            <handNote scope="major" script="nasta_liq" medium="blackink redink blueink">Nasta‘līḳ in black ink with red and
                                 blue inks for headings.</handNote>
                         </handDesc>
 
@@ -185,8 +169,7 @@
                         <additions>
                             <p><locus from="ia" to="ib">Flyleaf ia-b</locus> of volume 1 bears
                                 several invocations in Arabic.</p>
-                            <p><locus from="ia" to="ia">Flyleaf ia</locus> of volume 1 and <locus
-                                    from="106a" to="106a">folio 106a</locus> (in volume 2) give the
+                            <p><locus from="ia" to="ia">Flyleaf ia</locus> of volume 1 and <locus from="106a" to="106a">folio 106a</locus> (in volume 2) give the
                                 title of the work in Latin as <title key="">Historia Josephi et
                                     Zelichae, Turcicé</title> and <title key="">Josephi et Zelichae,
                                     Turcicé</title>, respectively.</p>
@@ -211,19 +194,13 @@
                     </physDesc>
                     <history>
 
-                        <origin> Place of origin unknown. Completed per the colophon in <origDate
-                                notBefore="1575-04-12" notAfter="1576-03-30"
-                                calendar="#Hijri-qamari">983</origDate>
-                            <origDate notBefore="1575-04-12" notAfter="1576-03-30"
-                                calendar="#Gregorian">1575/1576</origDate>. </origin>
+                        <origin> Place of origin unknown. Completed per the colophon in <origDate notBefore="1575-04-12" notAfter="1576-03-30" calendar="#Hijri-qamari">983</origDate>
+                            <origDate notBefore="1575-04-12" notAfter="1576-03-30" calendar="#Gregorian">1575/1576</origDate>. </origin>
 
-                        <provenance> The following inscription in Arabic on <locus from="1a" to="1a"
-                                >folio 1a</locus> of volume 1 suggests that this item entered the
+                        <provenance> The following inscription in Arabic on <locus from="1a" to="1a">folio 1a</locus> of volume 1 suggests that this item entered the
                             ownership of one <persName key="person_f8486" role="fmo">al-Faqīr Ḥāj Aḥmad
                                 al-Jalabī</persName> (<persName key="person_f8486" role="fmo">el-Faḳīr Ḥāc Aḥmed
-                                el-Çelebī</persName>) on <date when="1618-08-22"
-                                calendar="#Hijri-qamari">1 Ramażan 1027 AH</date> (<date
-                                when="1618-08-22" calendar="#Gregorian">1 Ramażan 1027 AH</date>):
+                                el-Çelebī</persName>) on <date when="1618-08-22" calendar="#Hijri-qamari">1 Ramażan 1027 AH</date> (<date when="1618-08-22" calendar="#Gregorian">1 Ramażan 1027 AH</date>):
                                 <quote>هثا کتاب یوسف زلیخا صاحبه الفقیر حاج احمد الجلبی في ۱ شهر
                                 رمضان سنه ۱۰۲۷</quote>.</provenance>
 
@@ -233,13 +210,10 @@
                                     (<persName>Ḫalīl bin ‘Ömer</persName>)</persName>.</provenance>
 
                         <provenance> Per an inscription on <locus from="ia" to="ia">flyleaf
-                                i</locus>, formerly owned by <persName role="fmo"
-                                key="person_237497"><persName>E. Bernard</persName>, i.e.
+                                i</locus>, formerly owned by <persName role="fmo" key="person_237497"><persName>E. Bernard</persName>, i.e.
                                     <persName>Edward Bernard, 1638 1696</persName></persName>. </provenance>
 
-                        <acquisition>Bought from the executors of the estate of <persName role="fmo"
-                                key="person_237497">Edward Bernard, 1638 1696</persName> in <date
-                                when="1698" calendar="#Gregorian">1698</date>.</acquisition>
+                        <acquisition>Bought from the executors of the estate of <persName role="fmo" key="person_237497">Edward Bernard, 1638 1696</persName> in <date when="1698" calendar="#Gregorian">1698</date>.</acquisition>
 
 
                     </history>
@@ -248,9 +222,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -259,9 +231,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -338,16 +308,11 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref
-                            target="https://id.loc.gov/authorities/subjects/sh2006003812.html"
-                            ><term key="subject_sh86000392">Joseph (Son of Jacob)--In the
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2006003812.html"><term key="subject_sh86000392">Joseph (Son of Jacob)--In the
                                 Koran</term></ref></item>
-                        <item><ref
-                            target="https://id.loc.gov/authorities/subjects/sh2006003812.html"
-                            ><term key="subject_sh2006003812">Love poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2006003812.html"><term key="subject_sh2006003812">Love poetry,
                                 Persian</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85129656.html"
-                            ><term key="subject_sh85129656">Sufi poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85129656.html"><term key="subject_sh85129656">Sufi poetry,
                                 Persian</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Bodl_Or_527.xml
+++ b/collections/oxford university/MS_Bodl_Or_527.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23288">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_527</idno>
@@ -51,9 +52,7 @@
                                 more information.</note>
                             <note>goods from Alexandria.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -70,9 +69,7 @@
                                 more information.</note>
                             <note>The first is لما ينصر.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,9 +98,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -111,9 +106,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_592.xml
+++ b/collections/oxford university/MS_Bodl_Or_592.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23168">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23168">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -54,7 +57,7 @@
                                 <persName xml:lang="chg-Latn-x">Mīr ‘Alī Šēr
                                 Nawā'ī</persName></persName>'s four-part series, <title>خزاٸن
                                 المعانی</title>
-                            <title>Ḫazā'inu l-ma‘ānī</title>. Though <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166">Ethé (1930: col. 1196)</ref> claims that the ghazals which comprise
+                            <title>Ḫazā'inu l-ma‘ānī</title>. Though <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé (1930: col. 1196)</ref> claims that the ghazals which comprise
                             the larger part of the manuscript are in alphabetical order, this does
                             not actually seem to be the case. Since the poems do not follow any
                             canonical order it is difficult to ascertain whether this manuscript
@@ -74,7 +77,7 @@
                             <textLang mainLang="chg">Chaghatay</textLang>
                             <note><locus from="ib" to="ib">Flyleaf 1b</locus> displays two short, seemingly random excerpts from the same work in the hand of the scribe. Their purpose is unknown.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -136,7 +139,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_632.xml
+++ b/collections/oxford university/MS_Bodl_Or_632.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23165">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23165">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                                     Bodl. Or. 668</ref> (complete) and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23166">MS.
                                     Bodl. Or. 693</ref> (partial).</filiation>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775201">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,7 +86,7 @@
                             <title key="work_23247" xml:lang="eng" type="desc">Notes in Ottoman Turkish in
                                 Syriac script and Arabic</title>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775201">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -151,7 +154,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_64.xml
+++ b/collections/oxford university/MS_Bodl_Or_64.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23248">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_64</idno>
@@ -68,9 +69,7 @@
                                 Kabus,' Berlin, 1811; a French version published by A. Querry,
                                 Paris, 1885, etc. Copied AH 974=AD 1566/1567.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -103,9 +102,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -113,9 +110,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_668.xml
+++ b/collections/oxford university/MS_Bodl_Or_668.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23163">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23163">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -70,7 +73,7 @@
                                 Middle Eastern Manuscripts Collection contain at least a portion of the same
                                 text: <ref target="https://www.fihrist.org.uk/catalog/manuscript_23165">MS. Bodl. Or. 632</ref> (complete) and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23166">MS. Bodl. Or. 693</ref> (partial).</filiation>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775201">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -149,7 +152,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_672.xml
+++ b/collections/oxford university/MS_Bodl_Or_672.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23151">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23151">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +78,7 @@
                            Or. 85</ref>. </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775161">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=25">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1185-1186 § (54)
@@ -129,7 +132,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Bodl_Or_689.xml
+++ b/collections/oxford university/MS_Bodl_Or_689.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23290">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_689</idno>
@@ -69,9 +70,7 @@
                                 and the frequent absence of catchwords makes it almost impossible to
                                 restore the proper order. Many little injuries besides.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -104,9 +103,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -114,9 +111,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_693.xml
+++ b/collections/oxford university/MS_Bodl_Or_693.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23166">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23166">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -61,14 +64,14 @@
                                 the same text: <ref target="https://www.fihrist.org.uk/catalog/manuscript_23163">MS.
                                     Bodl. Or. 668</ref> and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23165">MS.
                                     Bodl. Or. 632</ref>.</filiation>
-                            <note><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775201">Ethé(1930. col. 1266)</ref> suggests that the entirety of this
+                            <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé(1930. col. 1266)</ref> suggests that the entirety of this
                                 text corresponds to that in the other two manuscripts in the
                                 Bodleian, but only seems to have examined the first three prayers.
                                 Confirmation of the degree of similarity of this text to the others,
                                 and ascertainment of the presence or absence of additional texts
                                 await further study.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775201">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,7 +127,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Bodl_Or_72.xml
+++ b/collections/oxford university/MS_Bodl_Or_72.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23245">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_72</idno>
@@ -55,9 +56,7 @@
                                 fol. 60, 1st of Muḥarrem, AH 1009=AD 1600, July 13. Heading of the
                                 first letter: جناب سعادت مآب افندی حضرتدن حکمایه.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -77,9 +76,7 @@
                             <note>A story حکایت, beginning امدی پس ایدرلر که مکده بر ولی واردی کیجه
                                 و کوندوز عبادت مشغول ایدی الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -100,9 +97,7 @@
                             <note>The Prophet's last will وصّیت, beginning: حضرتارى صلى الله عليه
                                 وسلّم بیوردی که یا علی الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -121,9 +116,7 @@
                             <note>A firmān to the ʿulemā of the seaport of Avlôna, beginning: بودرکه
                                 لواء اولونیه ده واقع اولان عامه علما الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -156,9 +149,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -166,9 +157,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_729.xml
+++ b/collections/oxford university/MS_Bodl_Or_729.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23208">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_729</idno>
@@ -58,9 +59,7 @@
                                 The collection goes down to the letter only; the last line is a
                                 fard. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -96,9 +95,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -106,9 +103,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_741.xml
+++ b/collections/oxford university/MS_Bodl_Or_741.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23291">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_741</idno>
@@ -43,7 +44,7 @@
                         <summary>Vaṣiyetnāme-yi Birgeli and one other theological tract</summary>
                         <textLang mainLang="ota">Ottoman Turkish</textLang>
                         <msItem xml:id="MS_Bodl_Or_741-item1" n="1">
-                            <locus from="1a" to="88b"></locus>
+                            <locus from="1a" to="88b"/>
                             <title key="work_11395">Vaṣiyetnāme-yi Birgeli</title>
                             <title xml:lang="ota" key="work_11395">وصیت‌نامهٔ برگلی</title>
                             <author key="person_59888184">
@@ -59,9 +60,7 @@
                                 more information.</note>
                             <note>وصیت‌نامهٔ برگلی Vaṣiyetnāme-yi Birgeli; ends on fol. 88b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -84,9 +83,7 @@
                                 عند غيرها; in this second faṣl the copy breaks off abruptly, and the
                                 third is entirely missing. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -119,9 +116,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -129,9 +124,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_75.xml
+++ b/collections/oxford university/MS_Bodl_Or_75.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23187">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23187">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -87,9 +84,7 @@
                                     Lingua Turcica</title>, of whicht he first two words are stuck
                                 through.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775189"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=53">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,9 +103,7 @@
                             <incipit>حق بیوردی عزرافیله بیراق هی هی های هی های ایلت سلامم محّمد
                                 اشتیاق ویرمه جان نزعنده هیچ دردفراق</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -126,9 +119,7 @@
                                 glossary</title>
                             <incipit>کاغدنشان عنوان</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775192"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=56">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -191,9 +182,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -202,9 +191,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -281,18 +268,12 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2001000145.html"
-                            ><term key="subject_sh2001000145">Astrology, Turkish</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2009116097.html"
-                            ><term key="subject_sh2009116097">Astrology--Tables</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2001000141.html"
-                            ><term key="subject_sh2001000141">Islamic astrology</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85079628.html"
-                            ><term key="subject_sh85079628">Magic squares</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85079615.html"
-                            ><term key="subject_sh85079615">Islamic magic</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh86006922.html"
-                            ><term key="subject_sh86006922">Muḥammad, Prophet, d. 632--Miracles</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2001000145.html"><term key="subject_sh2001000145">Astrology, Turkish</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2009116097.html"><term key="subject_sh2009116097">Astrology--Tables</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2001000141.html"><term key="subject_sh2001000141">Islamic astrology</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85079628.html"><term key="subject_sh85079628">Magic squares</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85079615.html"><term key="subject_sh85079615">Islamic magic</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh86006922.html"><term key="subject_sh86006922">Muḥammad, Prophet, d. 632--Miracles</term></ref></item>
                     </list>
                 </keywords>
             </textClass>

--- a/collections/oxford university/MS_Bodl_Or_76.xml
+++ b/collections/oxford university/MS_Bodl_Or_76.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23205">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Bodl_Or_76</idno>
@@ -54,9 +55,7 @@
                                 corresponding to Laud Or. 38, fol. 1b, ln. 10-fol. 3b, ln.
                                 10.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,9 +82,7 @@
                                 counting in ciphers, numbers and letters of the Arabic alphabet, are
                                 found.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -118,9 +115,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -128,9 +123,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Bodl_Or_85.xml
+++ b/collections/oxford university/MS_Bodl_Or_85.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23157">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23157">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +78,7 @@
                            Or. 192</ref>, and MS. Bodl. Or. 85 (this manuscript). </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775162">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=26">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1187 § (60) 2098.</ref></bibl>
@@ -126,7 +129,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Canon_Or_116.xml
+++ b/collections/oxford university/MS_Canon_Or_116.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23294">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Canon_Or_116</idno>
@@ -90,9 +91,7 @@
                                 el-Ḥācī Muḥammed in the middle of Muḥarrem, A.H. 1045=A.D. 1635,
                                 beginning of July.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -125,9 +124,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -135,9 +132,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Canon_Or_124.xml
+++ b/collections/oxford university/MS_Canon_Or_124.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23295">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Canon_Or_124</idno>
@@ -66,9 +67,7 @@
                                 the Bodleian Library, p. 299. On a fly-leaf appears the name of
                                 Gianbattista Albrizzi of Venice, who flourished about 1740.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,9 +96,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -107,9 +104,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Canon_Or_132.xml
+++ b/collections/oxford university/MS_Canon_Or_132.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23296">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Canon_Or_132</idno>
@@ -90,9 +91,7 @@
                                 1083=A.D. 1673, Jan. 4; it is probably the autograph of the
                                 translator Vedādī.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -125,9 +124,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -135,9 +132,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Canon_Or_134-135.xml
+++ b/collections/oxford university/MS_Canon_Or_134-135.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23297">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Canon_Or_134_And_135</idno>
@@ -49,10 +50,8 @@
                                 یازدوغی انجیل مقدسدر اولکی ... فصل، كتاب ميلاد يسوع المسيح ابن داود
                                 بن ابراهيم الخ</incipit>
                             <author key="person_f8728">
-                                <persName
-                                    xml:lang="ota">Niʿmet bin Ḳudsī</persName>
-                                <persName
-                                    xml:lang="ota">نعمه بن قدسی</persName>
+                                <persName xml:lang="ota">Niʿmet bin Ḳudsī</persName>
+                                <persName xml:lang="ota">نعمه بن قدسی</persName>
                             </author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
@@ -84,9 +83,7 @@
                                 الواحد، متینگ یازدوغی انجیل مقدسدر اولکی . فصل، كتاب ميلاد يسوع
                                 المسيح ابن داود بن ابراهيم الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,9 +121,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +129,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Caps_Or_A_7.xml
+++ b/collections/oxford university/MS_Caps_Or_A_7.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23118">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23118">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -74,7 +77,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2055</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2055</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Caps_Or_C_11.xml
+++ b/collections/oxford university/MS_Caps_Or_C_11.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23115">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23115">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -61,7 +64,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775151">Ethé 2053</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=15">Ethé 2053</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Clarke_10.xml
+++ b/collections/oxford university/MS_Clarke_10.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23150">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23150">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +81,7 @@
                      <incipit>(<locus from="1b" to="1b">folio 1b</locus><!-- CHECK -->) حضرت حلیم
                         خلّاق و حکیم علی الاطلاق جلّت حکمته که وظاٸف لطاٸف حمد ثنای [...]</incipit>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1185 § (52) 2090.</ref></bibl>
@@ -133,7 +136,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_DOrville_543.xml
+++ b/collections/oxford university/MS_DOrville_543.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23138">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23138">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775157">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=21">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -85,7 +88,7 @@
                                         <width>20.3</width>
                                     </dimensions>
                                 </extent>
-                                <foliation><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775157">Ethé (1930: 1177-1179 § (41) 2079))</ref> suggests that the
+                                <foliation><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=21">Ethé (1930: 1177-1179 § (41) 2079))</ref> suggests that the
                                         folios as they are are out of order, with some having being
                                         rearranged upside-down.</foliation>
                             </supportDesc>

--- a/collections/oxford university/MS_Douce_Or_C_1.xml
+++ b/collections/oxford university/MS_Douce_Or_C_1.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23318">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Douce_Or_C_1</idno>
@@ -55,9 +56,7 @@
                                 toyseller, a courtesan, a bride, a man put in the pillory for
                                 selling with light weights, etc.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -82,17 +81,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_69848690"
-                                role="fmo dnr">Francis Douce, d. 1834</persName>.</provenance>
-                        <acquisition>The Douce bequest came to the Bodleian Library in <date
-                                calendar="#Gregorian" when="1834">1834</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_69848690" role="fmo dnr">Francis Douce, d. 1834</persName>.</provenance>
+                        <acquisition>The Douce bequest came to the Bodleian Library in <date calendar="#Gregorian" when="1834">1834</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -100,9 +95,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Douce_Or_C_2.xml
+++ b/collections/oxford university/MS_Douce_Or_C_2.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23319">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Douce_Or_C_2</idno>
@@ -93,9 +94,7 @@
                                 complying with the request kindly made to him by the keeper of the
                                 Library. London, March 9th, 1886".</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -120,17 +119,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_69848690"
-                                role="fmo dnr">Francis Douce, d. 1834</persName>.</provenance>
-                        <acquisition>The Douce bequest came to the Bodleian Library in <date
-                                calendar="#Gregorian" when="1834">1834</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_69848690" role="fmo dnr">Francis Douce, d. 1834</persName>.</provenance>
+                        <acquisition>The Douce bequest came to the Bodleian Library in <date calendar="#Gregorian" when="1834">1834</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -138,9 +133,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Douce_Or_a_1.xml
+++ b/collections/oxford university/MS_Douce_Or_a_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22922">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22922">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -50,7 +53,7 @@
                         ʻAlī</persName></title>
                      <textLang mainLang="fa" otherLangs="ar">Persian, Arabic</textLang>
                      <bibl>
-                        <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775232">Ethé 2381</ref>
+                        <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=96">Ethé 2381</ref>
                      </bibl>
                   </msItem>
                </msContents>

--- a/collections/oxford university/MS_Douce_Or_a_2.xml
+++ b/collections/oxford university/MS_Douce_Or_a_2.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22921">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22921">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                      <textLang mainLang="fa">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775234">Ethé 2387</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=98">Ethé 2387</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Douce_Or_a_3.xml
+++ b/collections/oxford university/MS_Douce_Or_a_3.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22923">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22923">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                      <textLang mainLang="fa">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775232">Ethé 2382</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=96">Ethé 2382</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Douce_Or_b_1.xml
+++ b/collections/oxford university/MS_Douce_Or_b_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22920">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22920">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -49,7 +52,7 @@
                         panels.</title>
                      <textLang mainLang="fa" otherLangs="ar">Persian, Arabic</textLang>
                      <bibl>
-                        <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775233">Ethé 2384</ref>
+                        <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=97">Ethé 2384</ref>
                      </bibl>
                   </msItem>
                </msContents>

--- a/collections/oxford university/MS_Douce_Or_b_3.xml
+++ b/collections/oxford university/MS_Douce_Or_b_3.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22917">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22917">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                      <textLang mainLang="fa">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775233">Ethé 2383</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=97">Ethé 2383</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Douce_Or_c_4.xml
+++ b/collections/oxford university/MS_Douce_Or_c_4.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22928">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22928">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                      <textLang mainLang="fa" otherLangs="ar">Persian, Arabic</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775231">Ethé 2379</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=95">Ethé 2379</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_E_D_Clarke_Or_16.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_16.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10916">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_10916">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +76,7 @@
                               Zweiter Band</title>. Leiden: Brill. 1943. p. 163: § 12. Kapitel.
                            Geographie und Kosmographie ¶ 8 (131). </bibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1179 § (42) 2080</ref>

--- a/collections/oxford university/MS_E_D_Clarke_Or_20.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_20.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23258">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_20</idno>
@@ -67,9 +68,7 @@
                                 circles and tables of the twelve months, beginning with ماه
                                 آذر.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=50">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -98,15 +97,12 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -114,9 +110,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_E_D_Clarke_Or_28.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_28.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23203">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_28</idno>
@@ -58,9 +59,7 @@
                                 fly-leaf at the end two Turkish ġazels are added, in another
                                 handwriting, the first beginning: عارف اول اى كوكل الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -88,18 +87,13 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" when="1649"
-                                >1059</origDate><origDate calendar="#Gregorian" when="1649"
-                                >1649</origDate></origin>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <origin><origDate calendar="#Hijri-qamari" when="1649">1059</origDate><origDate calendar="#Gregorian" when="1649">1649</origDate></origin>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -107,9 +101,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_E_D_Clarke_Or_29.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_29.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23209">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_29</idno>
@@ -63,9 +64,7 @@
                                 sail). On the Arabic original comp. Rieu, loc. cit.; Loth, Arabic
                                 MSS., p. 300; Krafft, No. 151, etc.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=38">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,15 +93,12 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -110,9 +106,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_E_D_Clarke_Or_35.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_35.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23299">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_35</idno>
@@ -67,9 +68,7 @@
                                 translation by the author himself, styled ترجمه انقاذ), and p. 197
                                 (غره‌نامه); see also the next item.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=61">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -109,9 +108,7 @@
                             <note>On ff. 50b-51b a short tract of three pages, style تجدید الایمان
                                 'the renewal of belief'</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=61">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +131,7 @@
                                 مسئله and جواب are left out, but always indicated by a small
                                 blank.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=61">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -165,15 +160,12 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -181,9 +173,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_E_D_Clarke_Or_37.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_37.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23243">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_37</idno>
@@ -63,9 +64,7 @@
                                 letters, especially by Ḫāverī Efendi, a تازیت‌نامه (read
                                 تعزیت‌نامه), and short pieces of Turkish poetry.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=47">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,15 +93,12 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -110,9 +106,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_E_D_Clarke_Or_48.xml
+++ b/collections/oxford university/MS_E_D_Clarke_Or_48.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23301">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_E_D_Clarke_Or_48</idno>
@@ -58,9 +59,7 @@
                                 Dated Constantinople, in Ramażān, A. H. 1215 A. D. 1801,
                                 Jan.-Febr.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -85,15 +84,12 @@
                     </physDesc>
                     <history>
                         <origin/>
-                        <provenance>The collections of <persName key="person_15552626" role="fmo"
-                                >Edward Daniel Clarke, d. 1822</persName>.</provenance>
+                        <provenance>The collections of <persName key="person_15552626" role="fmo">Edward Daniel Clarke, d. 1822</persName>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,9 +97,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Elliott_127.xml
+++ b/collections/oxford university/MS_Elliott_127.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22909">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22909">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -57,7 +60,7 @@
                      <textLang mainLang="chg" otherLangs="fa">Chagatai, Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775181">Ethé 2170</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=45">Ethé 2170</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Elliott_50.xml
+++ b/collections/oxford university/MS_Elliott_50.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23195">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23195">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -87,9 +84,7 @@
                                 استثنا الا الدین آمنوا بیراقوب شعراء اسلامی صحیح و سالم ساحل نجاته
                                 چکمش</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775171"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=35">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -128,8 +123,7 @@
                             <decoNote type="border">Textbox borders in blue, red, green, gold, and
                                 black throughout.</decoNote>
                             <decoNote type="headpiece">Gold cloud bands with red, blue, and purple
-                                floral designs around the main text on <locus from="1b" to="2a"
-                                    >folios 1b-2a</locus> and <locus from="9b" to="10a">folios
+                                floral designs around the main text on <locus from="1b" to="2a">folios 1b-2a</locus> and <locus from="9b" to="10a">folios
                                     9b-10a</locus>, as well as around the text of some ‘unvān
                                 throughout.</decoNote>
                             <decoNote type="miniature"><locus from="1a" to="1a">Folio 1a</locus>:
@@ -168,8 +162,7 @@
                         <provenance>The collections of <persName key="person_f6443" role="fmo">John
                                 Bardoe Elliott</persName>.</provenance>
 
-                        <acquisition>Presented to the Bodleian Library by <persName
-                                key="person_f6443" role="dnr">J.B. Elliott</persName>, in
+                        <acquisition>Presented to the Bodleian Library by <persName key="person_f6443" role="dnr">J.B. Elliott</persName>, in
                             1859.</acquisition>
 
                     </history>
@@ -178,9 +171,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -189,9 +180,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -268,16 +257,11 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2012002767.html"
-                                    ><term key="subject_sh2012002767">Sufi poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2012002767.html"><term key="subject_sh2012002767">Sufi poetry,
                                     Azerbaijani</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2007009620.html"
-                                    ><term key="subject_sh2007009620">Islamic poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2007009620.html"><term key="subject_sh2007009620">Islamic poetry,
                                     Azerbaijani</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85010644.html"
-                                    ><term key="subject_sh85010644">Azerbaijani
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85010644.html"><term key="subject_sh85010644">Azerbaijani
                             poetry</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Elliott_90.xml
+++ b/collections/oxford university/MS_Elliott_90.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23019">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23019">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +76,7 @@
                            91</ref> (partial), and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23169">MS. Turk. c.
                            7</ref> (partial).</filiation>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1196 § (75) 2113.</ref></bibl>

--- a/collections/oxford university/MS_Elliott_91.xml
+++ b/collections/oxford university/MS_Elliott_91.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23167">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23167">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                                     Laud Or. 283</ref> (complete), <ref target="https://www.fihrist.org.uk/catalog/manuscript_23019">MS.
                                         Elliot 90</ref> (partial), and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23169">MS. Turk. c. 7</ref> (partial).</filiation>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Greaves_19.xml
+++ b/collections/oxford university/MS_Greaves_19.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23302">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Greaves_19</idno>
@@ -69,9 +70,7 @@
                                 Şeyḫ Dik Ebū-alnik is noticed in W. Pertsch, Berlin Cat., p.
                                 183.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -100,19 +99,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_5061772" role="fmo"
-                                >John Greaves, d. 1652</persName> and <persName
-                                key="person_17570221" role="fmo">Thomas Greaves, d.
+                        <provenance>The collections of <persName key="person_5061772" role="fmo">John Greaves, d. 1652</persName> and <persName key="person_17570221" role="fmo">Thomas Greaves, d.
                             1676</persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1678">1678</date>.</acquisition>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1678">1678</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -120,9 +114,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Greaves_33.xml
+++ b/collections/oxford university/MS_Greaves_33.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23133">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23133">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -60,7 +63,7 @@
                                 tebṣīret el-nużamā</title>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Greaves_36.xml
+++ b/collections/oxford university/MS_Greaves_36.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23251">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Greaves_36</idno>
@@ -49,7 +50,7 @@
                             <author key="person_34377777">
                                 <persName xml:lang="ota-Latn-x-lc">Şeyḫ Vefā</persName>
                                 <persName xml:lang="ota">شیخ وفا</persName>
-                                <lb></lb>
+                                <lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Muṣṭafā bin Aḥmed aṣ-Ṣadrī el-Künevī</persName>
                                 <persName xml:lang="ota">مصطفی بن احمد الصدری الکنوی</persName>
                             </author>
@@ -81,9 +82,7 @@
                                 follow the tables of the twelve Syrian months, commencing with ماه
                                 آذر, arranged exactly as the first Vienna copy.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,19 +107,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_5061772" role="fmo"
-                                >John Greaves, d. 1652</persName> and <persName
-                                key="person_17570221" role="fmo">Thomas Greaves, d.
+                        <provenance>The collections of <persName key="person_5061772" role="fmo">John Greaves, d. 1652</persName> and <persName key="person_17570221" role="fmo">Thomas Greaves, d.
                             1676</persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1678">1678</date>.</acquisition>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1678">1678</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -128,9 +122,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Huntington_409.xml
+++ b/collections/oxford university/MS_Huntington_409.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23266">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Huntington_409</idno>
@@ -60,9 +61,7 @@
                                 viz. tables 18-41 and 60; the proper order of the remaining ones is:
                                 1, 10-13, 8, 3, 9, 2, 4-7, 14-17, and 42-59.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=52">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -87,18 +86,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_34684157" role="fmo"
-                                >Robert Huntington, d. <date calendar="#Gregorian" when="1701"
-                                    >1701</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1693">1693</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_34684157" role="fmo">Robert Huntington, d. <date calendar="#Gregorian" when="1701">1701</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1693">1693</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -106,9 +100,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Huntington_507.xml
+++ b/collections/oxford university/MS_Huntington_507.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23185">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23185">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -63,24 +60,18 @@
 
                         <summary>A collection of anonymous poetic legends about the life of
                                 <persName key="person_97245226" role="subject">the
-                                Prophet</persName>, <persName key="person_34436377" role="subject"
-                                >‘Alī</persName>, <persName key="person_30328354" role="subject"
-                                >Fāṭimah</persName> and the martyrdom of <persName
-                                key="person_89661385" role="subject">Ḥusayn</persName> in Old
+                                Prophet</persName>, <persName key="person_34436377" role="subject">‘Alī</persName>, <persName key="person_30328354" role="subject">Fāṭimah</persName> and the martyrdom of <persName key="person_89661385" role="subject">Ḥusayn</persName> in Old
                             Anatolian Turkish or Archaic Ottoman.</summary>
                         <textLang mainLang="ota">Old Anatolian/Archaic Ottoman Turkish</textLang>
 
                         <msItem xml:id="MS_Huntington_507-item1" n="1">
                             <locus from="1b" to="30b">folios 1b-30b</locus>
                             <author key="person_f407">anonymous</author>
-                            <title key="work_23361" type="desc">poem on the life of <persName
-                                    key="person_97245226" role="subject">the Prophet
+                            <title key="work_23361" type="desc">poem on the life of <persName key="person_97245226" role="subject">the Prophet
                                     Muḥammad</persName> in Old Anatolian Turkish</title>
                             <incipit>چون یاشنده ایردی مصطفی اندی ییره ضنکه خورشید سما</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -98,47 +89,32 @@
                             <title key="work_23362" xml:lang="ota">کتاب مقتل حسین</title>
                             <incipit>اوّل الله آدنی ذکر ایدالوم قدرتندن صنعتی فکر ایدالوم</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1199-1200 § (85)
                                     2123.</ref></bibl>
-                                <bibl><ref
-                                        target="https://dergiler.ankara.edu.tr/xmlui;/bitstream/handle/20.500.12575/29591/4526.pdf"
-                                        >Özçelik, Kenan. <title>Yûsuf-i Meddâh ve Maktel-i Hüseyn
+                                <bibl><ref target="https://dergiler.ankara.edu.tr/xmlui;/bitstream/handle/20.500.12575/29591/4526.pdf">Özçelik, Kenan. <title>Yûsuf-i Meddâh ve Maktel-i Hüseyn
                                             (İnceleme-Metin-Sözlük)</title>. Masters thesis. T.C.
                                         Ankara Üniversitesi, Sosyal Bilimler Enstitüsü, İslam Tarihi
                                         ve Sanatları (Türk İslam Edebiyatı) anabilim dalı.
                                         2008.</ref></bibl>
                             </listBibl>
-                            <note>One of several texts on the martyrdom of <persName
-                                    key="person_89661385" role="subject">Ḥusayn ibn ‘Alī</persName>
+                            <note>One of several texts on the martyrdom of <persName key="person_89661385" role="subject">Ḥusayn ibn ‘Alī</persName>
                                 which sometimes bears this title. A note on <locus from="205b">folio
                                     205b, line 4</locus> claims that the original mes̠nevī
-                                        <quote><date notBefore="1369-05-09" notAfter="1369-08-04"
-                                        calendar="#Hijri-qamari">یدی یوز یتمش اُچنده در
-                                    تمام</date></quote>, i.e. that it was completed <date
-                                    notBefore="1369-05-09" notAfter="1369-08-04"
-                                    calendar="#Gregorian">between 9 May and 4 August 1369</date>;
+                                        <quote><date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Hijri-qamari">یدی یوز یتمش اُچنده در
+                                    تمام</date></quote>, i.e. that it was completed <date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Gregorian">between 9 May and 4 August 1369</date>;
                                 whereas a similar note on <locus from="117a" to="117a">folio
                                     117a</locus> of an alternative version of this text in
                                     <ref>Bodleian Libraries MS. Laud 66</ref> states the that
-                                        <quote><date notBefore="1359-08-26" notAfter="1359-11-22"
-                                            calendar="#Hijri-qamari">یدی یوز آلتمش اوچندیدی
-                                    تمام</date></quote>, i.e. that it was originally completed <date
-                                    notBefore="1369-05-09" notAfter="1369-08-04"
-                                    calendar="#Gregorian">between 26 August and 22 November
+                                        <quote><date notBefore="1359-08-26" notAfter="1359-11-22" calendar="#Hijri-qamari">یدی یوز آلتمش اوچندیدی
+                                    تمام</date></quote>, i.e. that it was originally completed <date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Gregorian">between 26 August and 22 November
                                     1359</date>. The language of the text suggests that it is the
                                 same as the <title>Maḳtel-i Ḥüseyn</title> popularly attributed to
                                 either <persName key="person_83541911" role="att">Yūsuf-ı
-                                    Meddāḥ</persName>, <persName key="person_23155343865206310535"
-                                        role="att">Şādī Meddāḥ</persName>, a certain <persName key="person_f8474"
-                                    role="att">Ḳasṭamonılı Şāẕī</persName>, a certain <persName
-                                        key="person_f8475" role="att">‘Āşıḳī</persName>, or a certain <persName
-                                        key="person_f8476" role="att">Lūṭ oġlı Yaḥyā</persName>. Supporting this
+                                    Meddāḥ</persName>, <persName key="person_23155343865206310535" role="att">Şādī Meddāḥ</persName>, a certain <persName key="person_f8474" role="att">Ḳasṭamonılı Şāẕī</persName>, a certain <persName key="person_f8475" role="att">‘Āşıḳī</persName>, or a certain <persName key="person_f8476" role="att">Lūṭ oġlı Yaḥyā</persName>. Supporting this
                                 claim is the fact that some manuscripts with the same title (e.g.
                                 Ankara Milli Kütüphane manuscript no. 06 hk 2976/1) bear the same
                                 first couplet.</note>
@@ -152,21 +128,16 @@
                             <locus from="207a" to="207a">folio 207a</locus>
                             <author key="person_f407">anonymous</author>
                             <title key="work_23363" type="desc">eleven Old Anatolian Turkish bayts on the
-                                subject of <persName key="person_30328354" role="subject"
-                                    >Fāṭimah</persName></title>
+                                subject of <persName key="person_30328354" role="subject">Fāṭimah</persName></title>
                             <incipit>فاطمه ایدر</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note>This is not listed as a separate item in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>, but is collapsed into the previous
+                            <note>This is not listed as a separate item in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>, but is collapsed into the previous
                                 item.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
@@ -177,21 +148,16 @@
                             <author key="person_f407">anonymous</author>
                             <title key="work_23364" type="desc">Old Anatolian Turkish mes̠nevī on the lives of
                                     <persName key="person_97245226" role="subject">the Prophet
-                                    Muḥammad</persName> and <persName key="person_34436377"
-                                    role="subject">‘Alī</persName></title>
+                                    Muḥammad</persName> and <persName key="person_34436377" role="subject">‘Alī</persName></title>
                             <incipit>سلاٸل دیرلر بر قلعا واردی</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref> lists this item as number 3.</note>
+                            <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref> lists this item as number 3.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
                         </msItem>
@@ -203,17 +169,13 @@
                                 praise of Muḥammad</title>
                             <incipit>تنبیه ایدڭ عاشقلره مولود آیی کلدی ینه</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref> lists this item as number 4, which he
+                            <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref> lists this item as number 4, which he
                                 collapses into one paragraph with 5.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
@@ -226,17 +188,13 @@
                                 of Muḥammad</title>
                             <incipit>بحمد الله اول خلّاق دانه حکیم و عالم و حی و توانه</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref> lists this item as number 5, which he
+                            <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref> lists this item as number 5, which he
                                 collapses into one paragraph with 4.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
@@ -249,17 +207,13 @@
                                     <persName key="person_97245226" role="subject">the Prophet
                                     Muḥammad</persName></title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note>This is not listed as a separate item in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>, but is collapsed into the previous
+                            <note>This is not listed as a separate item in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>, but is collapsed into the previous
                                 item.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
@@ -272,17 +226,13 @@
                             <title key="work_23368" xml:lang="ota">معراج محمد مصطفی</title>
                             <incipit>اوّل الله آدنی یاد ایدلوم عشقنی کونولده بنیاد ایدلوم</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note>This is listed as item 6 in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>.</note>
+                            <note>This is listed as item 6 in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>.</note>
                             <textLang mainLang="ota">Old Anatolian/Archaic Ottoman
                                 Turkish</textLang>
                         </msItem>
@@ -293,18 +243,14 @@
                             <title key="work_23369" type="desc">several short prose pieces in Archaic Ottoman
                                 Turkish</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200-1201 § (85)
                                     2123.</ref></bibl>
                             </listBibl>
-                            <note>This is not listed as a separate item in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>, but is collapsed into the previous
+                            <note>This is not listed as a separate item in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>, but is collapsed into the previous
                                 item.</note>
                             <textLang mainLang="ota">Archaic Ottoman Turkish</textLang>
                         </msItem>
@@ -317,18 +263,14 @@
                             <title key="work_23370" xml:lang="ota">وصیّت‌نامهٔ مولانا محمّد بن فرامرز الشهر
                                 بمولانا حسرو رحمة الله علیه</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1200-1201 § (85)
                                     2123.</ref></bibl>
                             </listBibl>
-                            <note>This is not listed as a separate item in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>, but is collapsed into the previous
+                            <note>This is not listed as a separate item in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>, but is collapsed into the previous
                                 item.</note>
                             <textLang mainLang="ota">Archaic Ottoman Turkish</textLang>
                         </msItem>
@@ -339,17 +281,13 @@
                             <title key="work_23371" type="desc">short prayers in Archaic Ottoman
                                 Turkish</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1201 § (85) 2123.</ref></bibl>
                             </listBibl>
-                            <note>This is not listed as a separate item in <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                    >Ethé (1930:§2123)</ref>, but is collapsed into the previous
+                            <note>This is not listed as a separate item in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930:§2123)</ref>, but is collapsed into the previous
                                 item.</note>
                             <textLang mainLang="ota">Archaic Ottoman Turkish</textLang>
                         </msItem>
@@ -378,19 +316,15 @@
                     </physDesc>
                     <history>
 
-                        <origin> Place of origin unknown. According to a note on <locus from="207a"
-                                >folio 207a</locus>, at least part of the manuscript was completed
+                        <origin> Place of origin unknown. According to a note on <locus from="207a">folio 207a</locus>, at least part of the manuscript was completed
                             on <origDate when="1583-03-25" calendar="#Hijri-qamari">1 Rabī‘u l-evvel
                                 991</origDate>
                             <origDate when="1583-03-25" calendar="#Gregorian">25 March
                                 1583</origDate>. </origin>
 
-                        <provenance>The collections of <persName key="person_34684157" role="fmo"
-                                >Robert Huntington, d. <date calendar="#Gregorian" when="1701"
-                                    >1701</date></persName>.</provenance>
+                        <provenance>The collections of <persName key="person_34684157" role="fmo">Robert Huntington, d. <date calendar="#Gregorian" when="1701">1701</date></persName>.</provenance>
 
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1693">1693</date>.</acquisition>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1693">1693</date>.</acquisition>
 
                     </history>
 
@@ -398,9 +332,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -409,9 +341,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -488,18 +418,12 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85071619.html"
-                                    ><term key="subject_sh85071619">Karbalāʾ, Battle of, Karbalāʾ,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85071619.html"><term key="subject_sh85071619">Karbalāʾ, Battle of, Karbalāʾ,
                                     Iraq, 680</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85081664.html"
-                                    ><term key="subject_sh85081664"
-                            >Martyrdom--Islam</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85063203.html"
-                                    ><term key="subject_sh85063203">Ḥusayn ibn ʻAlī, -680--Death and
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85081664.html"><term key="subject_sh85081664">Martyrdom--Islam</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85063203.html"><term key="subject_sh85063203">Ḥusayn ibn ʻAlī, -680--Death and
                                     burial</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2021006778.html"
-                                    ><term key="subject_sh2021006778">Shiite poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2021006778.html"><term key="subject_sh2021006778">Shiite poetry,
                                 Turkish</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Huntington_598.xml
+++ b/collections/oxford university/MS_Huntington_598.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4506">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4506">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -86,7 +89,7 @@
 
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775159">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=23">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1181 § (45) 2085.</ref>

--- a/collections/oxford university/MS_Huntington_Donat_16.xml
+++ b/collections/oxford university/MS_Huntington_Donat_16.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23249">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Huntington_Donat_16</idno>
@@ -68,9 +69,7 @@
                                 the different phases of the moon and other planets, etc. Presented
                                 by Robert Huntington, Merton College, 1680.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,18 +98,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_34684157" role="fmo"
-                                >Robert Huntington, d. <date calendar="#Gregorian" when="1701"
-                                    >1701</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1693">1693</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_34684157" role="fmo">Robert Huntington, d. <date calendar="#Gregorian" when="1701">1701</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1693">1693</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -118,9 +112,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Huntington_donat_12.xml
+++ b/collections/oxford university/MS_Huntington_donat_12.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23176">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23176">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -66,7 +69,7 @@
                      <title key="work_23292" xml:lang="ota">اسکندرنامه</title>
                      <incipit>هر کمڭ کم یُلدشی توفیق اوله هرنه سُز کم سُیله تحقیق اوله</incipit>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1193 § (69) 2107.</ref></bibl>
@@ -120,7 +123,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Huntington_donat_15.xml
+++ b/collections/oxford university/MS_Huntington_donat_15.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23180">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23180">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -84,9 +81,7 @@
                                 کیدر</title>
                             <incipit> عاشق اولان معشوقه قربان کلور قربان کیدر </incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -113,9 +108,7 @@
                             <title key="work_23309" xml:lang="ota-Latn-x-lc">Ḥikāyet-i Şām</title>
                             <title key="work_23309" xml:lang="ota">حکایت شام</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -137,9 +130,7 @@
                             <title key="work_23310" xml:lang="ota-Latn-x-lc">Ḥikāyet-i cemāl</title>
                             <title key="work_23310" xml:lang="ota">حکایت جمال</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -162,9 +153,7 @@
                                 ‘Āczī</title>
                             <title key="work_23311" xml:lang="ota">نصیحت‌نامه (قصیده) | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -183,14 +172,11 @@
                             <title key="work_23312" xml:lang="ota-Latn-x-lc">Nūr Muḥammed ṣalavāt |
                                 Nāẓırī</title>
                             <title key="work_23312" xml:lang="ota">نور محمّد صلوات | ناظری</title>
-                            <note>The author of this work may or may not be the same as <persName
-                                    key="person_65608155" role="ant">Naẓīrī Nīshāpūrī, d. 1613</persName>, at
+                            <note>The author of this work may or may not be the same as <persName key="person_65608155" role="ant">Naẓīrī Nīshāpūrī, d. 1613</persName>, at
                                 which point this would have to be an Ottoman Turkish translation of
                                 one of his Persian works.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -212,9 +198,7 @@
                             <title key="work_23313" xml:lang="ota-Latn-x-lc">Ḥikāyet-i cān | ‘Āczī</title>
                             <title key="work_23313" xml:lang="ota">حکایت جان | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -237,9 +221,7 @@
                                 ‘Āczī</title>
                             <title key="work_23314" xml:lang="ota">نور محمّد صلوات | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -262,9 +244,7 @@
                             <title key="work_23315" xml:lang="ota-Latn-x-lc">Ḥikāyet-i vuṣlat</title>
                             <title key="work_23315" xml:lang="ota">حکایت وصلت</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -287,9 +267,7 @@
                                 ‘Āczī</title>
                             <title key="work_23316" xml:lang="ota">نصیحت‌نامه (مثنوی) | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -312,9 +290,7 @@
                             <title key="work_23317" xml:lang="ota-Latn-x-lc">Ḥikāyet-i göz</title>
                             <title key="work_23317" xml:lang="ota">حکایت کوز</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -337,9 +313,7 @@
                                 ‘Āczī</title>
                             <title key="work_23318" xml:lang="ota">حکایت اهل دل | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -362,9 +336,7 @@
                                 ‘Āczī</title>
                             <title key="work_23319" xml:lang="ota">حکایت اندر عدم | عاجزی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -386,9 +358,7 @@
                             <title key="work_23320" xml:lang="ota-Latn-x-lc">Ḥikāyet-i būy</title>
                             <title key="work_23320" xml:lang="ota">حکایت بوی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -410,9 +380,7 @@
                             <title key="work_23321" xml:lang="ota-Latn-x-lc">Ḥikāyet-i Ka‘be-i şerīf</title>
                             <title key="work_23321" xml:lang="ota">حکایت کعبهٔ شریف</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -434,9 +402,7 @@
                             <title key="work_23322" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ḳuṭbān</title>
                             <title key="work_23322" xml:lang="ota">حکایت قطبان</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -463,9 +429,7 @@
                             <title key="work_23323" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ẕikr-i müdām</title>
                             <title key="work_23323" xml:lang="ota">حکایت ذکر مدام</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -492,9 +456,7 @@
                             <title key="work_23324" xml:lang="ota-Latn-x-lc">Ḥikāyet-i dōst</title>
                             <title key="work_23324" xml:lang="ota">حکایت دوست</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -521,9 +483,7 @@
                             <title key="work_23325" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ‘īd</title>
                             <title key="work_23325" xml:lang="ota">حکایت عید</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -550,9 +510,7 @@
                             <title key="work_23326" xml:lang="ota-Latn-x-lc">Ḥikāyet-i celb</title>
                             <title key="work_23326" xml:lang="ota">حکایت جلب</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -579,9 +537,7 @@
                             <title key="work_23327" xml:lang="eng" type="desc">untitled mes̠nevī by Nacaḳ
                                 Fāżıl Nihānī</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -608,9 +564,7 @@
                             <title key="work_23328" xml:lang="ota-Latn-x-lc">Ḥikāyet-i şehr</title>
                             <title key="work_23328" xml:lang="ota">حکایت شهر</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -637,9 +591,7 @@
                             <title key="work_23329" xml:lang="ota-Latn-x-lc">Ḥikāyet-i çırāġ</title>
                             <title key="work_23329" xml:lang="ota">حکایت چراغ</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -666,9 +618,7 @@
                             <title key="work_23330" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ṣoḥbet</title>
                             <title key="work_23330" xml:lang="ota">حکایت صحبت</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -695,9 +645,7 @@
                             <title key="work_23331" xml:lang="ota-Latn-x-lc">Ḥikāyet-i fayż</title>
                             <title key="work_23331" xml:lang="ota">حکایت فیض</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -724,9 +672,7 @@
                                 Nihānī</title>
                             <title key="work_23332" xml:lang="ota">حکایت اندر عدم | نهانی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -753,9 +699,7 @@
                             <title key="work_23333" xml:lang="eng" type="desc">untitled ḳaṣīde by Nacaḳ Fāżıl
                                 Nihānī</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -782,9 +726,7 @@
                             <title key="work_23334" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ḫūrşīd | Nīhānī</title>
                             <title key="work_23334" xml:lang="ota">حکایت خورشید | نهانی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -811,9 +753,7 @@
                             <title key="work_23335" xml:lang="ota-Latn-x-lc">Ḥikāyet-i Vān</title>
                             <title key="work_23335" xml:lang="ota">حکایت وان</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -840,9 +780,7 @@
                             <title key="work_23336" xml:lang="eng" type="desc">untitled mes̠nevī by Nacaḳ
                                 Fāżıl Nihānī, wrongly labeled as a ḳaṣīde</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -870,9 +808,7 @@
                                 Nihānī</title>
                             <title key="work_23337" xml:lang="ota">حکایت اهل دل | نهانی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -899,9 +835,7 @@
                             <title key="work_23338" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ‘arefāt</title>
                             <title key="work_23338" xml:lang="ota">حکایت عرفات</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -928,9 +862,7 @@
                             <title key="work_23339" xml:lang="ota-Latn-x-lc">Ḥikāyet-i maḥfil</title>
                             <title key="work_23339" xml:lang="ota">حکایت محفل</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -957,9 +889,7 @@
                             <title key="work_23340" xml:lang="ota-Latn-x-lc">Ḥikāyet-i fikr</title>
                             <title key="work_23340" xml:lang="ota">حکایت فکر</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -986,9 +916,7 @@
                             <title key="work_23341" xml:lang="ota-Latn-x-lc">Ḥikāyet-i semek</title>
                             <title key="work_23341" xml:lang="ota">حکایت سمک</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1015,9 +943,7 @@
                             <title key="work_23355" xml:lang="ota-Latn-x-lc">Ḥikāyet-i dehr</title>
                             <title key="work_23355" xml:lang="ota">حکایت دهر</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1044,9 +970,7 @@
                             <title key="work_23342" xml:lang="ota-Latn-x-lc">Ḥikāyet-i Ka‘be</title>
                             <title key="work_23342" xml:lang="ota">حکایت کعبه</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1065,9 +989,7 @@
                             <title key="work_23343" xml:lang="ota-Latn-x-lc">Ḥikāyet-i ḫūrşīd | Ḥāżırī</title>
                             <title key="work_23343" xml:lang="ota">حکایت خورشید | حاضری</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1094,9 +1016,7 @@
                             <title key="work_23344" xml:lang="ota-Latn-x-lc">Ḥikāyet-i cān | Nihānī</title>
                             <title key="work_23344" xml:lang="ota">حکایت جان | نهانی</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1123,9 +1043,7 @@
                             <title key="work_23345" xml:lang="ota-Latn-x-lc">Ḥikāyet-i seyr</title>
                             <title key="work_23345" xml:lang="ota">حکایت سیر</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1153,9 +1071,7 @@
                             <title key="work_23346" xml:lang="ota-Latn-x-lc">Ḥikāyet-i furs</title>
                             <title key="work_23346" xml:lang="ota">حکایت فرس</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1177,9 +1093,7 @@
                             <title key="work_23347" xml:lang="eng" type="desc">untitled ḳaṣīde by
                                 ‘Āczī</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1201,9 +1115,7 @@
                             <title key="work_23347" xml:lang="eng" type="desc">untitled ḳaṣīde by
                                 ‘Āczī</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1219,9 +1131,7 @@
                             <title key="work_23348" xml:lang="eng" type="desc">seven short anonymous mes̠nevī
                                 in Ottoman Turkish</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1243,9 +1153,7 @@
                             <title key="work_23347" xml:lang="eng" type="desc">untitled ḳaṣīde by
                                 ‘Āczī</title>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1274,8 +1182,7 @@
                         </objectDesc>
 
                         <handDesc>
-                            <handNote scope="major" script="nasta_liq" medium="blackink redink"
-                                >Script: Nesta‘līḳ in black ink with section headings in red ink.
+                            <handNote scope="major" script="nasta_liq" medium="blackink redink">Script: Nesta‘līḳ in black ink with section headings in red ink.
                                 Scribe unknown.</handNote>
                         </handDesc>
 
@@ -1294,12 +1201,8 @@
 
                         <origin> Place and date of origin unknown. </origin>
 
-                        <provenance>The collections of <persName key="person_34684157" role="fmo"
-                                >Robert Huntington, d. <date calendar="#Gregorian" when="1701"
-                                    >1701</date></persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by <persName
-                                key="person_34684157" role="dnr">Robert Huntington, d. <date
-                                    calendar="#Gregorian" when="1701">1701</date></persName> in
+                        <provenance>The collections of <persName key="person_34684157" role="fmo">Robert Huntington, d. <date calendar="#Gregorian" when="1701">1701</date></persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by <persName key="person_34684157" role="dnr">Robert Huntington, d. <date calendar="#Gregorian" when="1701">1701</date></persName> in
                                 <date calendar="#Gregorian" when="1680">1680</date>.</acquisition>
                     </history>
 
@@ -1307,9 +1210,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -1318,9 +1219,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -1397,24 +1296,17 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh97005663.html"
-                                    ><term key="subject_sh97005663">Quatrains,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh97005663.html"><term key="subject_sh97005663">Quatrains,
                             Turkish</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2001000607.html"
-                                    ><term key="subject_sh2001000607">Masnavis,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2001000607.html"><term key="subject_sh2001000607">Masnavis,
                             Turkish</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh90000404.html"
-                                    ><term key="subject_sh90000404">Sufi poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh90000404.html"><term key="subject_sh90000404">Sufi poetry,
                                 Turkish</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85078591.html"
-                                    ><term key="subject_sh85078591">Love poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85078591.html"><term key="subject_sh85078591">Love poetry,
                                 Turkish</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh88000934.html"
-                                    ><term key="subject_sh88000934">Islamic poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh88000934.html"><term key="subject_sh88000934">Islamic poetry,
                                 Turkish</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85138898.html"
-                                    ><term key="subject_sh85138898">Turkish
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85138898.html"><term key="subject_sh85138898">Turkish
                             poetry</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Huntington_donat_6.xml
+++ b/collections/oxford university/MS_Huntington_donat_6.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23130">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23130">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -65,7 +68,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2067</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2067</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Hyde_1.xml
+++ b/collections/oxford university/MS_Hyde_1.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23247">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_1</idno>
@@ -52,9 +53,7 @@
                             <note>Ninety-five leaves are wholly or partially filled with writing.
                                 Between these a great number of blank pages.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -79,18 +78,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -98,9 +92,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_18.xml
+++ b/collections/oxford university/MS_Hyde_18.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23238">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_18</idno>
@@ -64,9 +65,7 @@
                                 1b, beginning: چون حضرت عطوف خالق البرايا و جناب رزق صاحب الكبريا
                                 الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -82,8 +81,7 @@
                                 ورقم</incipit>
                             <author key="person_f8501"><persName xml:lang="ota-Latn-x-lc">Tācīzāde Muḥammed
                                     Efendi</persName></author>
-                            <author key="person_f8500"><persName xml:lang="ota-Latn-x-lc"
-                                    >Kemālpaşazāde</persName></author>
+                            <author key="person_f8500"><persName xml:lang="ota-Latn-x-lc">Kemālpaşazāde</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -103,9 +101,7 @@
                                 On ff. 31-39 the usual counting tables (سیاقت نامه ورقم) are added.
                                 A few explanatory notes on the margin.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -133,21 +129,14 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" notBefore="1638" notAfter="1639"
-                                >1048</origDate><origDate calendar="#Gregorian" notBefore="1638"
-                                notAfter="1639">1638/1639</origDate></origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <origin><origDate calendar="#Hijri-qamari" notBefore="1638" notAfter="1639">1048</origDate><origDate calendar="#Gregorian" notBefore="1638" notAfter="1639">1638/1639</origDate></origin>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -155,9 +144,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_33.xml
+++ b/collections/oxford university/MS_Hyde_33.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23275">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_33</idno>
@@ -124,9 +125,7 @@
                                 complete, on ff. 1, 48-55, 66, 56-65, 67-76, and 178-326. Many
                                 marginal additions.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=54">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -138,8 +137,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>326 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>326 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="2" n="mistara" ruledLines="15">2 columns of 15
@@ -153,18 +151,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -172,9 +165,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_40.xml
+++ b/collections/oxford university/MS_Hyde_40.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23257">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_40</idno>
@@ -76,9 +77,7 @@
                                 بیان مدلولات طلوع شعرى يمانيه on fol. 10b. 5. جدول احکام خسوف كلى
                                 المرئى on fol. 11a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=50">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -103,18 +102,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -122,9 +116,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_41.xml
+++ b/collections/oxford university/MS_Hyde_41.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23264">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_41</idno>
@@ -111,9 +112,7 @@
                                 This copy came into the possession of İbrāhīm bin Ḳāsım el-Emīrcānī,
                                 AH 1029=AD 1620.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=51">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -142,18 +141,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -161,9 +155,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_43.xml
+++ b/collections/oxford university/MS_Hyde_43.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23303">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_43</idno>
@@ -71,9 +72,7 @@
                                 peregrinatione, etc., cum annott. Th. Hyde' (Appendix to Abraham
                                 Peritsol's 'Itinera Mundi,' Oxford, 1691).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=58">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -98,18 +97,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -117,9 +111,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Hyde_8.xml
+++ b/collections/oxford university/MS_Hyde_8.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23304">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Hyde_8</idno>
@@ -62,9 +63,7 @@
                                 sq. the same short tract is added, as in the preceding copy, viz.
                                 كلى موشح الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -93,18 +92,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_37848733" role="fmo"
-                                >Thomas Hyde, d. <date calendar="#Gregorian" when="1703"
-                                >1703</date></persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_37848733" role="fmo">Thomas Hyde, d. <date calendar="#Gregorian" when="1703">1703</date></persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -112,9 +106,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Ind_Misc_c_16.xml
+++ b/collections/oxford university/MS_Ind_Misc_c_16.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22933">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22933">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -50,7 +53,7 @@
                      <textLang mainLang="fa" otherLangs="ar">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775235">Ethé 2388</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=99">Ethé 2388</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Laud_Or_147.xml
+++ b/collections/oxford university/MS_Laud_Or_147.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23160">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23160">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -66,7 +69,7 @@
                            <persName xml:lang="ota">محمد بن عمر الحلبی</persName></persName>, as
                         well as other works on ethics with the same title.</note>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775163">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=27">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1190-1191 § (64)
@@ -120,7 +123,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Laud_Or_16.xml
+++ b/collections/oxford university/MS_Laud_Or_16.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23218">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_16</idno>
@@ -49,10 +50,8 @@
                                 of which are by Bāḳī</title>
                             <incipit xml:lang="ota"> خورشید رنگ کندوئى كم كوستره جانا الج ... شاد
                                 اولمق استین</incipit>
-                            <author key="person_88709578"><persName xml:lang="ota-Latn-x-lc"
-                                >Bāḳī</persName></author>
-                            <author key="person_f8500"><persName xml:lang="ota-Latn-x-lc"
-                                    >Kemālpaşazāde</persName></author>
+                            <author key="person_88709578"><persName xml:lang="ota-Latn-x-lc">Bāḳī</persName></author>
+                            <author key="person_f8500"><persName xml:lang="ota-Latn-x-lc">Kemālpaşazāde</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -64,9 +63,7 @@
                                 استین. This manuscript was presented to the Library by Archbishop
                                 Laud, 1633.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,18 +96,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -118,9 +111,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_175.xml
+++ b/collections/oxford university/MS_Laud_Or_175.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23226">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_175</idno>
@@ -45,8 +46,7 @@
                         <textLang mainLang="ota">Ottoman Turkish</textLang>
                         <msItem xml:id="MS_Laud_Or_175-item1" n="1">
                             <title key="work_23417">A scrap-book of Turkish poetry interspersed with a few prose pieces</title>
-                            <author key="person_45732466"><persName xml:lang="ota-Latn-x-lc"
-                                    >Nesīmī</persName>
+                            <author key="person_45732466"><persName xml:lang="ota-Latn-x-lc">Nesīmī</persName>
                                 <persName xml:lang="ota">نسیمی</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
@@ -59,9 +59,7 @@
                                 on ff. 15b18b. Presented to the Library by Archbishop Laud,
                                 1635.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -86,18 +84,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -105,9 +99,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_177.xml
+++ b/collections/oxford university/MS_Laud_Or_177.xml
@@ -61,7 +61,7 @@
                                 محبت افزون و صنوف تسليمات وافيات الخ. No date. Some lacunas here and
                                 there.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,7 +94,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Laud_Or_178.xml
+++ b/collections/oxford university/MS_Laud_Or_178.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23153">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23153">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +77,7 @@
                            Or. 85</ref>. </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775161">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=25">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1186 § (56) 2094.</ref></bibl>
@@ -125,7 +128,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Laud_Or_180.xml
+++ b/collections/oxford university/MS_Laud_Or_180.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23228">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_180</idno>
@@ -65,9 +66,7 @@
                                 other short lyrical poems follow. Not dated. This copy was presented
                                 to the Library by Archbishop Laud, 1633.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -96,18 +95,14 @@
                     </physDesc>
                     <history>
                         <origin/>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,9 +110,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_181.xml
+++ b/collections/oxford university/MS_Laud_Or_181.xml
@@ -74,7 +74,7 @@
                                 Mesīḥī (who died AH 918 AD 1512/1513, see above, No. 2150). Not
                                 dated.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=43">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -110,7 +110,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Laud_Or_202.xml
+++ b/collections/oxford university/MS_Laud_Or_202.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23124">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23124">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -60,7 +63,7 @@
                                 practice with French and Ottoman Turkish glosses</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775195">Ethé 2240</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé 2240</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>
@@ -81,7 +84,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Laud_Or_216.xml
+++ b/collections/oxford university/MS_Laud_Or_216.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22951">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22951">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +76,7 @@
                      <textLang mainLang="ota">Ottoman Turkish</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775172">Ethé 2137</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=36">Ethé 2137</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Laud_Or_259.xml
+++ b/collections/oxford university/MS_Laud_Or_259.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23231">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_259</idno>
@@ -60,9 +61,7 @@
                                 Flügel, Leipzig, 1845). Beginning the same as in the preceding copy.
                                 Presented to the Bodleian Library by Archbishop Laud, 1636.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=55">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -91,21 +90,15 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" when="1574"
-                                >981</origDate><origDate calendar="#Gregorian" when="1574"
-                                >1574</origDate></origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <origin><origDate calendar="#Hijri-qamari" when="1574">981</origDate><origDate calendar="#Gregorian" when="1574">1574</origDate></origin>
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -113,9 +106,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_283.xml
+++ b/collections/oxford university/MS_Laud_Or_283.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23018">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23018">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -68,7 +71,7 @@
                         Middle Eastern Collections of Oxford's Bodleian Libraries: <ref target="https://www.fihrist.org.uk/catalog/manuscript_23019">MS. Elliot
                            90</ref>, <ref target="https://www.fihrist.org.uk/catalog/manuscript_23167">MS. Elliot 91</ref>, and <ref target="https://www.fihrist.org.uk/catalog/manuscript_23169">MS. Turk. c. 7</ref>.</filiation>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775166">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=30">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1195 § (74) 2112.</ref></bibl>

--- a/collections/oxford university/MS_Laud_Or_38.xml
+++ b/collections/oxford university/MS_Laud_Or_38.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23200">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_38</idno>
@@ -67,9 +68,7 @@
                                 AH 981 AD 1574, January-February, by Seyyid ʿAlī bin Muṣṭafā of
                                 Brusa (i.e. Bursa).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=36">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -81,8 +80,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>70 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>70 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="2" n="mistara" ruledLines="15">2 columns of 15
@@ -100,21 +98,15 @@
                                 headpiece</decoNote></decoDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" when="1574"
-                                >981</origDate><origDate calendar="#Gregorian" when="1574"
-                                >1574</origDate></origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <origin><origDate calendar="#Hijri-qamari" when="1574">981</origDate><origDate calendar="#Gregorian" when="1574">1574</origDate></origin>
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -122,9 +114,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_40.xml
+++ b/collections/oxford university/MS_Laud_Or_40.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23227">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_40</idno>
@@ -66,9 +67,7 @@
                                 در اول. Copied AH 1015=AD 1606/1607. Presented to the Library by
                                 Archbishop Laud, 1633.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=44">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,18 +96,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -116,9 +111,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_48.xml
+++ b/collections/oxford university/MS_Laud_Or_48.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23235">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_48</idno>
@@ -80,9 +81,7 @@
                                 chronograms for AH 974 and 975. A single prose piece on fol. 19b,
                                 beginning: قال على كرم الله وجهه.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=41">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,18 +114,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +129,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_66.xml
+++ b/collections/oxford university/MS_Laud_Or_66.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23186">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23186">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -61,8 +58,7 @@
 
                     <msContents>
 
-                        <summary>A mes̠nevī on the martyrdom of <persName key="person_89661385"
-                                role="subject">Ḥusayn</persName> in Old Anatolian Turkish.</summary>
+                        <summary>A mes̠nevī on the martyrdom of <persName key="person_89661385" role="subject">Ḥusayn</persName> in Old Anatolian Turkish.</summary>
 
                         <textLang mainLang="ota">Old Anatolian Turkish</textLang>
 
@@ -73,44 +69,30 @@
                             <incipit>اوّل الله آدنی ذکر ایده‌لوم قدرتندن صانعی فکر
                                 ایده‌لوم</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775168"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1201 § (86) 2124.</ref></bibl>
-                                <bibl><ref
-                                        target="https://dergiler.ankara.edu.tr/xmlui;/bitstream/handle/20.500.12575/29591/4526.pdf"
-                                        >Özçelik, Kenan. <title>Yûsuf-i Meddâh ve Maktel-i Hüseyn
+                                <bibl><ref target="https://dergiler.ankara.edu.tr/xmlui;/bitstream/handle/20.500.12575/29591/4526.pdf">Özçelik, Kenan. <title>Yûsuf-i Meddâh ve Maktel-i Hüseyn
                                             (İnceleme-Metin-Sözlük)</title>. Masters thesis. T.C.
                                         Ankara Üniversitesi, Sosyal Bilimler Enstitüsü, İslam Tarihi
                                         ve Sanatları (Türk İslam Edebiyatı) anabilim dalı.
                                         2008.</ref></bibl>
                             </listBibl>
-                            <note>One of several texts on the martyrdom of <persName
-                                    key="person_89661385" role="subject">Ḥusayn ibn ‘Alī</persName>
-                                which sometimes bears this title. A note on <locus from="117a"
-                                    to="117a">folio 117a</locus> claims the that this mes̠nevī
-                                        <quote><date notBefore="1359-08-26" notAfter="1359-11-22"
-                                        calendar="#Hijri-qamari">یدی یوز آلتمش اوچندیدی
-                                    تمام</date></quote>, i.e. that it was originally completed <date
-                                    notBefore="1369-05-09" notAfter="1369-08-04"
-                                    calendar="#Gregorian">between 26 August and 22 November
+                            <note>One of several texts on the martyrdom of <persName key="person_89661385" role="subject">Ḥusayn ibn ‘Alī</persName>
+                                which sometimes bears this title. A note on <locus from="117a" to="117a">folio 117a</locus> claims the that this mes̠nevī
+                                        <quote><date notBefore="1359-08-26" notAfter="1359-11-22" calendar="#Hijri-qamari">یدی یوز آلتمش اوچندیدی
+                                    تمام</date></quote>, i.e. that it was originally completed <date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Gregorian">between 26 August and 22 November
                                     1359</date>; whereas <locus from="205b">folio 205b, line
                                     4</locus> of an alternative version of this text in
                                     <ref>Bodleian Libraries MS. Huntington 507, item 2</ref> states
-                                        <quote><date notBefore="1369-05-09" notAfter="1369-08-04"
-                                        calendar="#Hijri-qamari">یدی یوز یتمش اُچنده در
-                                    تمام</date></quote>, i.e. that it was completed <date
-                                    notBefore="1369-05-09" notAfter="1369-08-04"
-                                    calendar="#Gregorian">between 9 May and 4 August 1369</date>.
+                                        <quote><date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Hijri-qamari">یدی یوز یتمش اُچنده در
+                                    تمام</date></quote>, i.e. that it was completed <date notBefore="1369-05-09" notAfter="1369-08-04" calendar="#Gregorian">between 9 May and 4 August 1369</date>.
                                 The language of the text suggests that it is the same as the
                                     <title>Maḳtel-i Ḥüseyn</title> popularly attributed to either
                                     <persName key="person_83541911" role="att">Yūsuf-ı
-                                    Meddāḥ</persName>, <persName key="person_23155343865206310535"
-                                    role="att">Şādī Meddāḥ</persName>, a certain <persName
-                                    key="person_f8474" role="att">Ḳasṭamonılı Şāẕī</persName>, a
+                                    Meddāḥ</persName>, <persName key="person_23155343865206310535" role="att">Şādī Meddāḥ</persName>, a certain <persName key="person_f8474" role="att">Ḳasṭamonılı Şāẕī</persName>, a
                                 certain <persName key="person_f8475" role="att">‘Āşıḳī</persName>,
                                 or a certain <persName key="person_f8476" role="att">Lūṭ oġlı
                                     Yaḥyā</persName>. Supporting this claim is the fact that some
@@ -147,11 +129,9 @@
 
                         <origin> Place and date of origin unknown. </origin>
 
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
 
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
 
 
@@ -161,9 +141,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -172,9 +150,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -251,18 +227,12 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85071619.html"
-                                    ><term key="subject_sh85071619">Karbalāʾ, Battle of, Karbalāʾ,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85071619.html"><term key="subject_sh85071619">Karbalāʾ, Battle of, Karbalāʾ,
                                     Iraq, 680</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85081664.html"
-                                    ><term key="subject_sh85081664"
-                            >Martyrdom--Islam</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85063203.html"
-                                    ><term key="subject_sh85063203">Ḥusayn ibn ʻAlī, -680--Death and
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85081664.html"><term key="subject_sh85081664">Martyrdom--Islam</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85063203.html"><term key="subject_sh85063203">Ḥusayn ibn ʻAlī, -680--Death and
                                     burial</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2021006778.html"
-                                    ><term key="subject_sh2021006778">Shiite poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2021006778.html"><term key="subject_sh2021006778">Shiite poetry,
                                 Turkish</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Laud_Or_67.xml
+++ b/collections/oxford university/MS_Laud_Or_67.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23237">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_67</idno>
@@ -71,9 +72,7 @@
                                 1520-1566); and a صورت حکم شریف برای فتح مصر on fol. 72b. Persian
                                 and Arabic words are explained on the margin.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,21 +100,15 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" notBefore="1599" notAfter="1600"
-                                >1008</origDate><origDate calendar="#Gregorian" notBefore="1599"
-                                notAfter="1600">1599/1600</origDate></origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <origin><origDate calendar="#Hijri-qamari" notBefore="1599" notAfter="1600">1008</origDate><origDate calendar="#Gregorian" notBefore="1599" notAfter="1600">1599/1600</origDate></origin>
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -123,9 +116,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Laud_Or_70.xml
+++ b/collections/oxford university/MS_Laud_Or_70.xml
@@ -60,7 +60,7 @@
                                 بیان سیاقت عربی و رقم and going from 1 to 900,000,000. Copied AH
                                 1007=AD 1598/1599.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -79,7 +79,7 @@
                                 90,000,000,000,000). No date. This manuscript came into Archbishop
                                 Laud's library, 1635.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,7 +115,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Laud_Or_76.xml
+++ b/collections/oxford university/MS_Laud_Or_76.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23188">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23188">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -78,16 +75,12 @@
                             <incipit>ای جان ب کونکل مهرك ایله واله و شیدا اثباتنك ایچون کون و مکان
                                 اولدی هدایت</incipit>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1201 § (88) 2126.</ref></bibl>
-                                <bibl><ref
-                                        target="https://tez.yok.gov.tr/UlusalTezMerkezi/TezGoster?key=XohQ0H2mJnBfxLPsY8dG48frqU-Oou-6DL5ugPBLPgFkC0gUJBvGOFn4dXq1Opqh"
-                                        >Sona, İbrahim. <title>Hidayet Çelebi ve divanı / Hidayet
+                                <bibl><ref target="https://tez.yok.gov.tr/UlusalTezMerkezi/TezGoster?key=XohQ0H2mJnBfxLPsY8dG48frqU-Oou-6DL5ugPBLPgFkC0gUJBvGOFn4dXq1Opqh">Sona, İbrahim. <title>Hidayet Çelebi ve divanı / Hidayet
                                             Celebi and his divan</title>. Masters thesis, T.C. Gazi
                                         Üniversitesi, Sosyal Bilimler Enstitüsü, Eski Türk Edebiyatı
                                         Bilim Dalı. 2006.</ref></bibl>
@@ -114,8 +107,7 @@
 
                         <handDesc>
                             <handNote scope="major" script="naskh" medium="blackink">Script: Clear
-                                and distinct nesḫ. Scribe: <persName key="person_f8477" role="scr"><persName
-                                        xml:lang="ota-Latn-x-lc">Pīr Ḥüseyn el-Kātib</persName>
+                                and distinct nesḫ. Scribe: <persName key="person_f8477" role="scr"><persName xml:lang="ota-Latn-x-lc">Pīr Ḥüseyn el-Kātib</persName>
                                     <persName xml:lang="ota">پیر حسین
                                 الکاتب</persName></persName>.</handNote>
                         </handDesc>
@@ -126,17 +118,13 @@
                     </physDesc>
                     <history>
 
-                        <origin> Place of origin unknown. Dated <origDate notBefore="1497-12-15"
-                                notAfter="1497-12-31" calendar="#Hijri-qamari">early Cemāẕī'ü
+                        <origin> Place of origin unknown. Dated <origDate notBefore="1497-12-15" notAfter="1497-12-31" calendar="#Hijri-qamari">early Cemāẕī'ü
                                 l-evvel 903</origDate>
-                            <origDate notBefore="1497-12-15" notAfter="1497-12-31"
-                                calendar="#Gregorian">late December 1497</origDate>. </origin>
+                            <origDate notBefore="1497-12-15" notAfter="1497-12-31" calendar="#Gregorian">late December 1497</origDate>. </origin>
 
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
 
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
 
 
@@ -146,9 +134,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -157,9 +143,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -236,8 +220,7 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh87005477.html"
-                                    ><term key="subject_sh87005477">Alexander, the Great, 356-323
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh87005477.html"><term key="subject_sh87005477">Alexander, the Great, 356-323
                                     B.C.--Legends</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Laud_Or_82.xml
+++ b/collections/oxford university/MS_Laud_Or_82.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23240">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Laud_Or_82</idno>
@@ -47,8 +48,7 @@
                         <msItem xml:id="MS_Laud_Or_82-item1" n="1">
                             <title key="work_23423" type="desc">An interesting and probably unique collection of mystical
                                 treatises both in prose and verse.</title>
-                            <author cert="medium" key="person_28458747"><persName xml:lang="ota-Latn-x-lc"
-                                >Selim I, Sultan of the Turks, 1470-1520</persName></author>
+                            <author cert="medium" key="person_28458747"><persName xml:lang="ota-Latn-x-lc">Selim I, Sultan of the Turks, 1470-1520</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -74,9 +74,7 @@
                                 سافلین. This copy was presented to the Library by Archbishop Laud,
                                 1635.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=43">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -105,18 +103,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_54940373" role="fmo"
-                                >Archbishop William Laud, d. 1645</persName>.</provenance>
-                        <acquisition>Donated to the Bodleian Library by <persName
-                                key="person_54940373" role="dnr">Archbishop William Laud</persName>,
+                        <provenance>The Library of <persName key="person_54940373" role="fmo">Archbishop William Laud, d. 1645</persName>.</provenance>
+                        <acquisition>Donated to the Bodleian Library by <persName key="person_54940373" role="dnr">Archbishop William Laud</persName>,
                             1635-41.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,9 +118,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_179.xml
+++ b/collections/oxford university/MS_Marsh_179.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23196">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23196">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -62,8 +59,7 @@
                     <msContents>
 
                         <summary>One autograph (?) copy of a trilingual Ottoman Turkish, Latin, and
-                            Hungarian poetic risāle in praise of Islam by <persName
-                                xml:lang="ota-Latn-x-lc">Murād the Interpreter</persName>.</summary>
+                            Hungarian poetic risāle in praise of Islam by <persName xml:lang="ota-Latn-x-lc">Murād the Interpreter</persName>.</summary>
                         <textLang mainLang="ota" otherLangs="hun lat">Ottoman Turkish, Hungarian,
                             and Latin, all three in both Latin and Arabic script</textLang>
 
@@ -95,13 +91,10 @@
                                 whence the Ottoman Turkish reads: <quote>بو رساله اوج دیل اوزره
                                     منظوم تطبیق اولنمشدر ترجمان مراد الندن ترجمه اتمك و یازمق
                                     یونندن</quote></note>
-                            <note>A facsimile of this manuscript is available in <ref
-                                    target="https://doi.org/10.1515/9783111412221"> Babinger et al.,
+                            <note>A facsimile of this manuscript is available in <ref target="https://doi.org/10.1515/9783111412221"> Babinger et al.,
                                     1927</ref>.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775171"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=35">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -133,17 +126,14 @@
                                 <layout columns="2" ruledLines="15" n="mistara"> 2 columns of 15
                                     lines per page on <locus from="1b" to="3a">folios 1b-3a</locus>. </layout>
                                 <layout columns="3" ruledLines="27" n="mistara"> 3 columns of 27
-                                    lines per page (13 interlinear Arabic-script lines) on <locus
-                                        from="3b" to="22a">folios 3b-22a</locus>. </layout>
+                                    lines per page (13 interlinear Arabic-script lines) on <locus from="3b" to="22a">folios 3b-22a</locus>. </layout>
                             </layoutDesc>
                         </objectDesc>
 
                         <handDesc>
-                            <handNote scope="major" script="nasta_liq" medium="blackink redink"
-                                >Script (Arabic): Nesta‘līḳ in black in with red ink for headings
+                            <handNote scope="major" script="nasta_liq" medium="blackink redink">Script (Arabic): Nesta‘līḳ in black in with red ink for headings
                                 and prose notes. Script (Latin): Minimally cursive Renaissance
-                                bastard hand. Scribe: likely the author, <persName
-                                    xml:lang="ota-Latn-x-lc" role="scr">Murād the
+                                bastard hand. Scribe: likely the author, <persName xml:lang="ota-Latn-x-lc" role="scr">Murād the
                                     Interpreter</persName>.</handNote>
                         </handDesc>
 
@@ -157,12 +147,10 @@
                         <origin><ref target="https://doi.org/10.1515/9783111412221">Babinger (1927:
                                 42)</ref> argues that this manuscript is an autograph copy by
                                 <persName xml:lang="ota-Latn-x-lc">Murād the Interpreter</persName>
-                            himself, and dates it on the basis of the text to <origDate
-                                calendar="#Gregorian" notBefore="1580-05" notAfter="1582-12-05">May
+                            himself, and dates it on the basis of the text to <origDate calendar="#Gregorian" notBefore="1580-05" notAfter="1582-12-05">May
                                 1580 and 5 December 1582</origDate>. </origin>
 
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
 
@@ -172,9 +160,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -183,9 +169,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -262,23 +246,14 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2009127610.html"
-                                    ><term key="subject_sh2009127610">Islam--Apologetic works--Early
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2009127610.html"><term key="subject_sh2009127610">Islam--Apologetic works--Early
                                     works to 1800</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2009119575.html"
-                                    ><term key="subject_sh2009119575">Christianity and other
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2009119575.html"><term key="subject_sh2009119575">Christianity and other
                                     religions--Islam--Early works to 1800</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85046930.html"
-                                    ><term key="subject_sh85046930">Faith
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85046930.html"><term key="subject_sh85046930">Faith
                             (Islam)</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85068406.html"
-                                    ><term key="subject_sh85068406"
-                                    >Islam--Relations--Christianity.</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85068410.html"
-                                    ><term key="subject_sh85068410"
-                                >Islam--Universality.</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85068406.html"><term key="subject_sh85068406">Islam--Relations--Christianity.</term></ref></item>
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85068410.html"><term key="subject_sh85068410">Islam--Universality.</term></ref></item>
                     </list>
                 </keywords>
             </textClass>

--- a/collections/oxford university/MS_Marsh_180.xml
+++ b/collections/oxford university/MS_Marsh_180.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23141">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23141">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -115,7 +118,7 @@
                         الْکِتَابِ</colophon>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775159">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=23">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1182-1183 § (50) 2088</ref>

--- a/collections/oxford university/MS_Marsh_187.xml
+++ b/collections/oxford university/MS_Marsh_187.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23307">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Marsh_187</idno>
@@ -42,8 +43,7 @@
                     </msIdentifier>
                     <msContents>
                         <summary>Lüġatnama</summary>
-                        <textLang mainLang="ota" otherLangs="lat gre tat arm srp bos hrv ron"
-                            >Ottoman Turkish, Latin, Greek, Tatar, Armenian,
+                        <textLang mainLang="ota" otherLangs="lat gre tat arm srp bos hrv ron">Ottoman Turkish, Latin, Greek, Tatar, Armenian,
                             Bosnian-Serbian-Croation-Montenegrin, and Romanian-Moldovan</textLang>
                         <msItem xml:id="MS_Marsh_187-item1" n="1">
                             <title key="">Lüġatnama</title>
@@ -60,24 +60,20 @@
                                 omitted. The Latin words only are arranged in alphabetical
                                 order.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. § (201) 2239.</ref></bibl>
                             </listBibl>
-                            <textLang mainLang="ota" otherLangs="lat gre tat arm srp bos hrv ron"
-                                >Ottoman Turkish, Latin, Greek, Tatar, Armenian,
+                            <textLang mainLang="ota" otherLangs="lat gre tat arm srp bos hrv ron">Ottoman Turkish, Latin, Greek, Tatar, Armenian,
                                 Bosnian-Serbian-Croation-Montenegrin, and Romanian-Moldovan</textLang>
                         </msItem>
                     </msContents>
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>181 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>181 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara">1 column of varying number of lines
@@ -91,17 +87,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -109,9 +102,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_193.xml
+++ b/collections/oxford university/MS_Marsh_193.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23308">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Marsh_193</idno>
@@ -86,9 +87,7 @@
                                 dialectical peculiarities and other additions. The first word is
                                 اِپْ funis.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=58">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -113,17 +112,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -131,9 +127,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_196.xml
+++ b/collections/oxford university/MS_Marsh_196.xml
@@ -1,4 +1,6 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23108">
     <teiHeader>
         <fileDesc>
@@ -18,8 +20,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -58,9 +59,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775149"
-                                        >Ethé 2045</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=13">Ethé 2045</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>
@@ -88,15 +87,13 @@
                     </physDesc>
                     <history>
                         <origin>
-                            <origDate cert="medium" notAfter="1566-09-06" notBefore="1520-09-30"
-                                calendar="#Gregorian">Probably completed during the reign of
+                            <origDate cert="medium" notAfter="1566-09-06" notBefore="1520-09-30" calendar="#Gregorian">Probably completed during the reign of
                                     <persName role="subject" key="person_89743257">Ḳānūnī Sulṭān
                                     Süleymān</persName>, i.e. between 30 September 1520 and 6
                                 September 1566</origDate>
                             <origPlace cert="medium">likely İstanbul</origPlace>.
                         </origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
@@ -113,9 +110,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>

--- a/collections/oxford university/MS_Marsh_245.xml
+++ b/collections/oxford university/MS_Marsh_245.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23159">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23159">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +76,7 @@
                      <note><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé (1930: col. 1189)</ref> cites a claim made by <ref target="https://archive.org/details/catalogueofpersi02brituoft/mode/2up">Rieu (1879</ref> -- though that claim could not be found on page 219, as Ethé suggests) that this translation
                         was likely made during the reign of <persName role="dte" key="person_86538783">Meḥmed II</persName> (1432-1481), but does not elaborate.</note>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775163">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=27">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1188-1190 § (62)
@@ -123,7 +126,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Marsh_246.xml
+++ b/collections/oxford university/MS_Marsh_246.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23136">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23136">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                                 quotes in Arabic</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_25.xml
+++ b/collections/oxford university/MS_Marsh_25.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_11583">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_11583">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,9 +61,7 @@
                      جميع شاذ أولسون اما بعد بنلروک ادوار لرندن بر روح استادلر مختصر
                      بنياد اتدلركم الخ.</incipit>
                   <listBibl>
-                     <bibl><ref
-                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                     <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                            Hindûstânî and Pushtû Manuscripts in the Bodleian
                            Library, Part II: Turkish, Hindûstânî, Pushtû and
                            Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_253.xml
+++ b/collections/oxford university/MS_Marsh_253.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23311">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Marsh_253</idno>
@@ -56,9 +57,7 @@
                             <note>The English words are arranged alphabetically, beginning with: to
                                 abandon, براقمق, ; to abuse, الجاقلمق etc.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,17 +82,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,9 +97,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_313.xml
+++ b/collections/oxford university/MS_Marsh_313.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23114">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23114">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -53,7 +56,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775150">Ethé 2051</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=14">Ethé 2051</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Marsh_350.xml
+++ b/collections/oxford university/MS_Marsh_350.xml
@@ -72,7 +72,7 @@
                                 1622-1643.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=47">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,7 +108,7 @@
                                 94b; W. Pertsch, Berlin Cat., p. 471; G. Flügel i. p. 266; Krafft,
                                 p. 28; H. Khalfa vi. p. 185, etc. No date.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=47">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -141,7 +141,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_364.xml
+++ b/collections/oxford university/MS_Marsh_364.xml
@@ -60,7 +60,7 @@
                                 written in pencil by Golius, are found occasionally, especially
                                 towards the end.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -96,7 +96,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_409.xml
+++ b/collections/oxford university/MS_Marsh_409.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23120">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23120">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -61,7 +64,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2057</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2057</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Marsh_42.xml
+++ b/collections/oxford university/MS_Marsh_42.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1108">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1108">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -109,7 +112,7 @@
                            Or. 85</ref>. </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1187 § (57) 2096.</ref></bibl>

--- a/collections/oxford university/MS_Marsh_43.xml
+++ b/collections/oxford university/MS_Marsh_43.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23314">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Marsh_43</idno>
@@ -59,9 +60,7 @@
                                 concise manner. Beginning, on fol. 1b: حضرت آدم علیه السلام جمعه
                                 کونی روح شریفی داخل اولدوغندن اوتورى الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -103,9 +102,7 @@
                                 طراوت بخش الخ. The beginning of Rieu's copy appears here, but with
                                 slight modifications, on fol. 74b, 1. 5 ab infra.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -135,9 +132,7 @@
                                 identical with the poet Nihānī, quoted above in Ethe No. 2149, is
                                 impossible to say.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -163,9 +158,7 @@
                             <note>حکایت بایزید بسطامی, a tale of Bāyezīd Bisṭāmī (who died A. H.
                                 261=A. D. 875), on fol. 103b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -190,9 +183,7 @@
                             <note>حكايت حاتم اصم, a tale of Hatim the deaf who died A. H. 237=A.D.
                                 851/852, on fol. 110b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -209,9 +200,7 @@
                                 more information.</note>
                             <note>حکایت مروان, a story of Marwān, on fol. 111a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -231,9 +220,7 @@
                                 more information.</note>
                             <note>نصائح ملوك, advices to kings, on fol. 111b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -255,9 +242,7 @@
                             <note>رسالة مشكلات, a treatise on difficult questions on fol.
                                 113a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -288,9 +273,7 @@
                             <note>رسالة علم الفراست ارسطالیس a treatise on physiognomy, ascribed to
                                 Aristotle, on fol. 119b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -314,9 +297,7 @@
                             <note>وصیت‌نامه حضرت علی الله کرم وجهه, the last will of ʿAlī on fol.
                                 123b. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -347,17 +328,14 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -365,9 +343,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_454.xml
+++ b/collections/oxford university/MS_Marsh_454.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23142">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23142">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -168,7 +171,7 @@
 
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1180 § (43) 2081</ref>
@@ -189,7 +192,7 @@
 
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1180 § (43) 2082</ref>

--- a/collections/oxford university/MS_Marsh_557.xml
+++ b/collections/oxford university/MS_Marsh_557.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23246">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Marsh_557</idno>
@@ -57,9 +58,7 @@
                                 1593/1594. Numerous Latin annotations in pencil, both marginal and
                                 interlinear, throughout (made in 1642).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=36">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -87,20 +86,15 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" notBefore="1593" notAfter="1594"
-                                >1002</origDate><origDate calendar="#Gregorian" notBefore="1593"
-                                notAfter="1594">1593/1594</origDate></origin>
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <origin><origDate calendar="#Hijri-qamari" notBefore="1593" notAfter="1594">1002</origDate><origDate calendar="#Gregorian" notBefore="1593" notAfter="1594">1593/1594</origDate></origin>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,9 +102,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Marsh_568.xml
+++ b/collections/oxford university/MS_Marsh_568.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_11803">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_11803">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,9 +64,7 @@
                      <listBibl>
                         <bibl>Appendix Lexicography</bibl>
                         <bibl>[Uri Turc. 66]</bibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=56">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_598.xml
+++ b/collections/oxford university/MS_Marsh_598.xml
@@ -1,4 +1,6 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1150">
    <teiHeader>
       <fileDesc>
@@ -58,9 +60,7 @@
                      <note>mes̠'eles, referring to the rites and observances of Islām, according to
                         the Hanafite doctrine, on ff. 1b-5a, in Turkish.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -69,15 +69,12 @@
                   </msItem>
                   <msItem xml:id="MS_Marsh_598-item2" n="2">
                      <locus from="5" to="30">folios. 5b-30b</locus>
-                     <author key="person_51676273" ref="http://www.viaf.org/viaf/51676273/"
-                        change="#ids-cleanup">
+                     <author key="person_51676273" ref="http://www.viaf.org/viaf/51676273/" change="#ids-cleanup">
                         <persName type="standard" xml:lang="ar-Latn-x-lc">Abū al-Layth
-                           al-Samarqandī, Naṣr ibn Muḥammad, d. <date calendar="#Gregorian"
-                              when="0983" cert="unknown">983</date>
+                           al-Samarqandī, Naṣr ibn Muḥammad, d. <date calendar="#Gregorian" when="0983" cert="unknown">983</date>
                         </persName>
                      </author>
-                     <title xml:lang="ar-Latn-x-lc" key="work_3290" change="#ids-cleanup"
-                        >al-Muqaddimah fī al-ṣalāh</title>
+                     <title xml:lang="ar-Latn-x-lc" key="work_3290" change="#ids-cleanup">al-Muqaddimah fī al-ṣalāh</title>
                      <title xml:lang="ara" key="work_3290">المقدمة في الصلاح</title>
                      <listBibl>
                         
@@ -98,9 +95,7 @@
                         information.</note>
                      <note>Another short set of mes̠'eles, in Turkish, on fol. 31.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -122,9 +117,7 @@
                         ريحًا صرصرًا فى ايام و مختلف في کلام حسات، وقال ابن عباس الخ. Dated end of
                         Ẕī l-ḥicce, A.H. 1052=A. D. 1643, March 21.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -142,9 +135,7 @@
                         regulations as to their prayers, on ff. 53-60b, in Turkish; the first part
                         is headed دعاء سنجاق في البر, the second علمداران.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -169,9 +160,7 @@
                         of the fifty bābs in prose; the poem itself begins, on fol. 62b, last line,
                         thus: چون بسم الله اولدی ابتداسی ينه حمديله اولسون انتهاسی</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -191,9 +180,7 @@
                         ff. 123b-131b, in Turkish. Beginning: رسول الله حدیثنده بیوردی اسلام قیدنی
                         نجه قیوردی كور.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -215,9 +202,7 @@
                      <note>Another copy of Şeyḫ Vefā's تقویم, or perpetual calendar (see Nos.
                         2193-2195 above), on ff. 132b-140a, in Turkish.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -251,9 +236,7 @@
                         on fol. 151b; December (heading missing, this month seems to begin on fol.
                         153a); January (), on fol. 154b; February (), on fol. 155b.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -270,9 +253,7 @@
                         information.</note>
                      <note>A third set of mes̠'eles, in Turkish, on ff. 1578-159a.</note>
                      <listBibl>
-                        <bibl><ref
-                              target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                              >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=69">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. § (254) 2292.</ref></bibl>
@@ -301,10 +282,8 @@
                         Golius</persName> [see Golius Sale Catalogue, Libri Miscellanei M.S. in
                      quarto &amp;c, no. 58].</provenance>
                   <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop
-                        Narcissus Marsh, d. <date calendar="#Gregorian" when="1713"
-                        >1713</date></persName>.</provenance>
-                  <acquisition>The Marsh bequest entered the Bodleian Library in <date
-                        calendar="#Gregorian" when="1714">1714</date>.</acquisition>
+                        Narcissus Marsh, d. <date calendar="#Gregorian" when="1713">1713</date></persName>.</provenance>
+                  <acquisition>The Marsh bequest entered the Bodleian Library in <date calendar="#Gregorian" when="1714">1714</date>.</acquisition>
                </history>
                <additional>
                   <adminInfo>
@@ -315,8 +294,7 @@
                      </recordHist>
                      <availability status="restricted">
                         <p>Entry to read in the Library is permitted only on presentation of a valid
-                           reader's card (for admissions procedures contact <ref
-                              target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                           reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                               Admissions</ref>).</p>
                      </availability>
                   </adminInfo>
@@ -390,22 +368,18 @@
                <list>
                   <item>
                      <ref target="#a1">
-                        <term key="subject_sh85106123"
-                           target="http://id.loc.gov/authorities/sh85106123#concept"
-                           >Prayer--Islam</term>
+                        <term key="subject_sh85106123" target="http://id.loc.gov/authorities/sh85106123#concept">Prayer--Islam</term>
                      </ref>
                   </item>
                   <item>
                      <ref target="#a2">
-                        <term key="subject_sh85068403"
-                           target="http://id.loc.gov/authorities/sh85068403#concept">Islam--Prayers
+                        <term key="subject_sh85068403" target="http://id.loc.gov/authorities/sh85068403#concept">Islam--Prayers
                            and devotions</term>
                      </ref>
                   </item>
                   <item>
                      <ref target="#a2">
-                        <term key="subject_sh85058192"
-                           target="http://id.loc.gov/authorities/sh85058192#concept">Hadith</term>
+                        <term key="subject_sh85058192" target="http://id.loc.gov/authorities/sh85058192#concept">Hadith</term>
                      </ref>
                   </item>
                </list>
@@ -418,30 +392,20 @@
             <persName>Julian Cook</persName> Changed person and work ids (Fihrist data cleanup
             project). </change>
          <change when="2018-06-08">
-            <persName>Andrew Morrison</persName> Updated key attributes using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl"
-               >update-keys.xsl</ref>
+            <persName>Andrew Morrison</persName> Updated key attributes using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/update-keys.xsl">update-keys.xsl</ref>
          </change>
          <change when="2018-03-28" xml:id="add-summary2">
-            <persName>Andrew Morrison</persName> Adjusted summary using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries2.xsl"
-               >add-summaries2.xsl</ref>
+            <persName>Andrew Morrison</persName> Adjusted summary using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries2.xsl">add-summaries2.xsl</ref>
          </change>
          <change when="2018-03-15" xml:id="add-summary">
-            <persName>Andrew Morrison</persName> Added summary using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl"
-               >add-summaries.xsl</ref>
+            <persName>Andrew Morrison</persName> Added summary using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/add-summaries.xsl">add-summaries.xsl</ref>
          </change>
          <change when="2018-03-02" xml:id="fix-dates">
             <persName>Andrew Morrison</persName> Removed origDate tags around something which is not
-            a date using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl"
-               >fix-dates.xsl</ref>
+            a date using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/conversion_scripts/fix-dates.xsl">fix-dates.xsl</ref>
          </change>
          <change when="2017-11-07">
-            <persName>James Cummings</persName> Up-converted the markup using <ref
-               target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl"
-               >https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl">https://github.com/bodleian/fihrist-mss/tree/master/processing/convertFihrist2Bodley.xsl</ref>
          </change>
          <change when="2009-05-14">created this file</change>
       </revisionDesc>

--- a/collections/oxford university/MS_Marsh_61.xml
+++ b/collections/oxford university/MS_Marsh_61.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23148">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23148">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +79,7 @@
                      <incipit>(<locus from="1b" to="1b">folio 1b</locus>) سپاس و ستایش ایله قادرڭزدر جلّ جلاجه که آثار قدرتی روز روشن چهره‌سنده تاباندر <!--CHECK!--></incipit>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775160">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=24">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1184-1184 § (51) 2089.</ref>
@@ -115,7 +118,7 @@
                <additional>
                   <adminInfo>
                      <recordHist>
-                        <source><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <source><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Marsh_633.xml
+++ b/collections/oxford university/MS_Marsh_633.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23189">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23189">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -62,8 +59,7 @@
                     <msContents>
 
                         <summary>One copy of <persName key="person_47178052" role="author">Hamdullah
-                                Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc"
-                                >Yūsuf ü Züleyḫā</title> in Ottoman Turkish, several anonymous short
+                                Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title> in Ottoman Turkish, several anonymous short
                             mes̠nevīs in Ottoman Turkish, a single bayt in Persian, a short
                             anonymous <title>Fetḥnāme-i Rodos</title> mostly in Ottoman Turkish, and
                             several calendrical squares.</summary>
@@ -73,7 +69,7 @@
                         <msItem xml:id="MS_Marsh_633-item1" n="1">
                             <locus from="1a" to="215a">folios 1a-215a</locus>
                             <author key="person_47178052">
-                                <persName>Hamdullah Hamdi, 1449-1508</persName><lb></lb>
+                                <persName>Hamdullah Hamdi, 1449-1508</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Ḥamdüllāh Ḥamdī</persName>
                                 <persName xml:lang="ota">حمد الله حمدی</persName>
                             </author>
@@ -88,30 +84,19 @@
                                 والمؤمنات فی الیوم الاثنین من خهر ربیع الاخر فی الخامس والعشرین من
                                 سنه ۹۳۸</colophon>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. col. 1201-1202 § (89)
                                     2127.</ref></bibl>
                             </listBibl>
-                            <note>A complete copy of <persName key="person_47178052" role="author"
-                                    >Ḥamdüllāh Ḥamdī</persName>'s <title key=""
-                                    xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title>, modeled on the
-                                    <title key="work_20147">Yūsuf va-Zulaykhā</title> of <persName
-                                    key="person_90042997" role="ant">Jāmī</persName> and completed
-                                in <date notBefore="1491-11-04" notAfter="1492-10-22"
-                                    calendar="#Gregorian">897 AH</date> (<date
-                                    notBefore="1491-11-04" notAfter="1492-10-22"
-                                    calendar="#Gregorian">between 4 November 1491 and 22 October
-                                    1492 CE</date>). The colophon on <locus from="215a" to="215a"
-                                    >folio 215a</locus> is in Arabic.</note>
-                            <filiation>At least one other complete (<ref
-                                target="https://www.fihrist.org.uk/catalog/manuscript_23190">MS.
-                                Bodl. Or. 515-518</ref>) and one partial (<ref
-                                    target="https://www.fihrist.org.uk/catalog/manuscript_23191">MS.
+                            <note>A complete copy of <persName key="person_47178052" role="author">Ḥamdüllāh Ḥamdī</persName>'s <title key="" xml:lang="ota-Latn-x-lc">Yūsuf ü Züleyḫā</title>, modeled on the
+                                    <title key="work_20147">Yūsuf va-Zulaykhā</title> of <persName key="person_90042997" role="ant">Jāmī</persName> and completed
+                                in <date notBefore="1491-11-04" notAfter="1492-10-22" calendar="#Gregorian">897 AH</date> (<date notBefore="1491-11-04" notAfter="1492-10-22" calendar="#Gregorian">between 4 November 1491 and 22 October
+                                    1492 CE</date>). The colophon on <locus from="215a" to="215a">folio 215a</locus> is in Arabic.</note>
+                            <filiation>At least one other complete (<ref target="https://www.fihrist.org.uk/catalog/manuscript_23190">MS.
+                                Bodl. Or. 515-518</ref>) and one partial (<ref target="https://www.fihrist.org.uk/catalog/manuscript_23191">MS.
                                     Laud Or. 87</ref>) copy of the same text exist in the Bodleian
                                 Libraries.</filiation>
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
@@ -126,10 +111,8 @@
                                 تَجَلّیٕ بُورِ اَعْظَم</incipit>
                             <explicit>هَمْ کَمِکْدُرْ هَمْ سَکِردُرْ هَمْ دَریٕ انیٕ یِیرْلَرْ هَپْ
                                 خَلْقُك اَکْثَریٕ</explicit>
-                            <note>This section contains six poems of differing lengths titled <title
-                                    type="sub" xml:lang="ota">مداد</title>
-                                <title type="sub" xml:lang="ota-Lang-x-lc">midād</title>, <title
-                                    type="sub" xml:lang="ota">قلم</title>
+                            <note>This section contains six poems of differing lengths titled <title type="sub" xml:lang="ota">مداد</title>
+                                <title type="sub" xml:lang="ota-Lang-x-lc">midād</title>, <title type="sub" xml:lang="ota">قلم</title>
                                 <title type="sub" xml:lang="ota-Lang-x-lc">ḳalem</title>, (left
                                 blank), <title type="sub" xml:lang="ota">ابریق خاك</title>
                                 <title type="sub" xml:lang="ota-Lang-x-lc">ibrīḳ-ı ḫāk</title>,
@@ -139,16 +122,13 @@
                                 <title type="sub" xml:lang="ota-Lang-x-lc">kīs ü nuḳūd</title>. Most
                                 title appear in their own boxes in red ink, however the first has
                                 been added in black ink on the border of the textbox, seemingly as
-                                an afterthought. The last poem has the word <title type="sub"
-                                    xml:lang="ota">پاچه</title>
+                                an afterthought. The last poem has the word <title type="sub" xml:lang="ota">پاچه</title>
                                 <title type="sub" xml:lang="ota-Lang-x-lc">pāçe</title> written in
                                 the gap between the two columns before the final bayt, suggesting
                                 that this may constitute a separate poem or separate section of the
                                 larger work.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -164,15 +144,11 @@
                             <author key="person_f407">anonymous</author>
                             <title type="desc">an anonymous bayt in Persian</title>
                             <note>A single bayt in Persian, apparently in a different hand to the
-                                rest of the manuscript, with a strange title that could read <title
-                                    xml:lang="per-Latn-x-lc">Lughazgar</title>
-                                <title xml:lang="per">لغزگر</title> "The Riddler" or <title
-                                    xml:lang="per-Latn-x-lc">Lughazak</title>
+                                rest of the manuscript, with a strange title that could read <title xml:lang="per-Latn-x-lc">Lughazgar</title>
+                                <title xml:lang="per">لغزگر</title> "The Riddler" or <title xml:lang="per-Latn-x-lc">Lughazak</title>
                                 <title xml:lang="per">لغزك</title> "A Little Riddle".</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -200,9 +176,7 @@
                                 year fo the conquest of Rhodes (929 AH), which has been clarified in
                                 red ink by a different hand immediately thereafter.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -223,9 +197,7 @@
                             <title key="work_23375" xml:lang="per">جدول معروفة الایّام اینست</title>
                             <note>Two calendrical tables.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775169"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=33">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -260,8 +232,7 @@
                                     <locus from="1a" to="215a">possibly 217a-b and</locus>
                                     <locus from="1a" to="215a">222a-b</locus>
                                 </locusGrp>) Scribe: Possible the same as the person who penned and
-                                dated the colophon, i.e. <persName key="person_f8484" role="scr"><persName
-                                        xml:lang="ota-Latn-x-lc">Şa‘bān bin Ḳāsım</persName>
+                                dated the colophon, i.e. <persName key="person_f8484" role="scr"><persName xml:lang="ota-Latn-x-lc">Şa‘bān bin Ḳāsım</persName>
                                         (<persName xml:lang="ara-Latn-x-lc">Sha‘bān bin
                                         Qāsim</persName>) <persName xml:lang="ota">شعبان بن
                                         قاسم</persName></persName>, though it should be said that
@@ -276,8 +247,7 @@
 
                         <additions>
                             <p>Several notes appear on <locus from="1a" to="1a">folio 1a</locus>: <list>
-                                    <item>At the top of the page is a note in Greek by <persName
-                                            key="person_22965285" role="fmo">Archbishop Narcissus
+                                    <item>At the top of the page is a note in Greek by <persName key="person_22965285" role="fmo">Archbishop Narcissus
                                             Marsh</persName> which reads <quote>πανταχή τὴν
                                             ἀλήθειαν</quote>.</item>
                                     <item>The title of the first work is given as <quote>کِتَابِ
@@ -296,14 +266,12 @@
                     <history>
 
                         <origin>According to the colophon at the end of the largest text, it (and
-                            likely the following text in the same hand) were completed on <origDate
-                                when="1531-11-06" calendar="#Hijri-qamari">25 Rabī‘u l-evvel
+                            likely the following text in the same hand) were completed on <origDate when="1531-11-06" calendar="#Hijri-qamari">25 Rabī‘u l-evvel
                                 938</origDate>
                             <origDate when="1531-11-06" calendar="#Gregorian">6 November
                                 1531</origDate>. Place of origin unknown. </origin>
 
-                        <provenance>The Library of <persName key="person_22965285" role="fmo"
-                                >Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
+                        <provenance>The Library of <persName key="person_22965285" role="fmo">Archbishop Narcissus Marsh, d. 1713</persName>.</provenance>
                         <acquisition>The Marsh bequest entered the Bodleian Library in
                             1714.</acquisition>
 
@@ -313,10 +281,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Entry based on observation of the manuscript by <persName
-                                    key="person_311784694" role="cataloguer">Nicholas Kontovas</persName> and the previous description in <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Entry based on observation of the manuscript by <persName key="person_311784694" role="cataloguer">Nicholas Kontovas</persName> and the previous description in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -325,9 +290,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -404,16 +367,11 @@
             <textClass>
                 <keywords scheme="#LCSH">
                     <list>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2006003812.html"
-                                    ><term key="subject_sh86000392">Joseph (Son of Jacob)--In the
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2006003812.html"><term key="subject_sh86000392">Joseph (Son of Jacob)--In the
                                     Koran</term></ref></item>
-                        <item><ref
-                                target="https://id.loc.gov/authorities/subjects/sh2006003812.html"
-                                    ><term key="subject_sh2006003812">Love poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh2006003812.html"><term key="subject_sh2006003812">Love poetry,
                                 Persian</term></ref></item>
-                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85129656.html"
-                                    ><term key="subject_sh85129656">Sufi poetry,
+                        <item><ref target="https://id.loc.gov/authorities/subjects/sh85129656.html"><term key="subject_sh85129656">Sufi poetry,
                                 Persian</term></ref></item>
                     </list>
                 </keywords>

--- a/collections/oxford university/MS_Marsh_82.xml
+++ b/collections/oxford university/MS_Marsh_82.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1239">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1239">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -71,9 +74,7 @@
                         p. 338, and J. C. Tornberg, p. 240. It has been printed in
                         Constantinople, A. H. 1260 and 1282.</note>
                      <listBibl>
-                        <bibl><ref
-                           target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                           >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=67">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                               Hindûstânî and Pushtû Manuscripts in the Bodleian
                               Library, Part II: Turkish, Hindûstânî, Pushtû and
                               Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Ouseley_103.xml
+++ b/collections/oxford university/MS_Ouseley_103.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23146">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23146">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -69,7 +72,7 @@
                             <title key="work_23243" xml:lang="ota">جاماسب‌نامه</title>
 
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775159">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=23">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -131,7 +134,7 @@
                             <recordHist>
                                 <source>
                                     <listBibl>
-                                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian,
+                                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian,
                                                   Turkish, Hindûstânî and Pushtû Manuscripts in the
                                                   Bodleian Library, Part II: Turkish, Hindûstânî,
                                                   Pushtû and Additional Persian Manuscripts</title>.

--- a/collections/oxford university/MS_Ouseley_121.xml
+++ b/collections/oxford university/MS_Ouseley_121.xml
@@ -57,7 +57,7 @@
                                 appointed governor, 1536=AH 942, 943, see Hammer, Osman. Dichtkunst,
                                 ii. p. 545), rhyming in ش and ز.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,7 +89,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Ouseley_125.xml
+++ b/collections/oxford university/MS_Ouseley_125.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_12899">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_12899">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -85,7 +88,7 @@
                      <textLang mainLang="ota">Ottoman Turkish</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775196">Ethé 2249</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé 2249</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Ouseley_159.xml
+++ b/collections/oxford university/MS_Ouseley_159.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xml:id="manuscript_23201">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23201">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -29,8 +27,7 @@
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
                         <addrLine>
-                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref>
+                            <ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref>
                         </addrLine>
                         <addrLine>
                             <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
@@ -77,11 +74,9 @@
                             factum. See the histories of the individual parts below for
                             details.</origin>
 
-                        <provenance>The collections of <persName key="person_44733962" role="fmo"
-                                >Sir Gore Ouseley, d. 1844</persName></provenance>
+                        <provenance>The collections of <persName key="person_44733962" role="fmo">Sir Gore Ouseley, d. 1844</persName></provenance>
 
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1858">1858</date>.</acquisition>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1858">1858</date>.</acquisition>
 
                     </history>
 
@@ -91,9 +86,7 @@
                             <recordHist>
                                 <source> Description based on the observation of the manuscript by
                                         <persName key="person_311784694" role="cataloguer">Nicholas
-                                        Kontovas</persName> and the corresponding entry in <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                        Kontovas</persName> and the corresponding entry in <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -102,9 +95,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript</p>
@@ -125,8 +116,7 @@
 
                         <msContents>
 
-                            <summary>the Persian travel journal of <persName key="person_242015466"
-                                    xml:lang="per-Latn-x-lc">Mīrzā Muḥammad Ṣāliḥ
+                            <summary>the Persian travel journal of <persName key="person_242015466" xml:lang="per-Latn-x-lc">Mīrzā Muḥammad Ṣāliḥ
                                 Shīrāzī</persName></summary>
                             <textLang mainLang="per">Persian</textLang>
 
@@ -146,9 +136,7 @@
                                 <incipit type="basmala">بسم الله الرحمن الرحیم</incipit>
                                 <incipit>در بیان کیفیت مجملی از احوالات اصفهان</incipit>
                                 <listBibl>
-                                    <bibl><ref
-                                            target="https://archive.org/details/catalogueofpersi01bodluoft/page/536/mode/2up?view=theater"
-                                            >Sachau, Ed. and Ethé, Hermann. <title>Catalogue of the
+                                    <bibl><ref target="https://archive.org/details/catalogueofpersi01bodluoft/page/536/mode/2up?view=theater">Sachau, Ed. and Ethé, Hermann. <title>Catalogue of the
                                                 Persian, Turkish, Hindûstânî and Pushtû Manuscripts
                                                 in the Bodleian Library</title>. Oxford: Clarendon
                                             Press. 1889. col. 1071 § 1856.</ref></bibl>
@@ -156,16 +144,13 @@
                                 <textLang mainLang="per">Persian</textLang>
                                 <note>The descriptive English title appears in a later hand on
                                         <locus from="1a" to="1a">folio 1a</locus> as "Journal of M.
-                                    Salih", i.e. <persName xml:lang="per-Latn-x-lc" role="aut scr"
-                                            ><persName xml:lang="per-Latn-x-lc">Mīrzā Muḥammad Ṣāliḥ
+                                    Salih", i.e. <persName xml:lang="per-Latn-x-lc" role="aut scr"><persName xml:lang="per-Latn-x-lc">Mīrzā Muḥammad Ṣāliḥ
                                             Shīrāzī</persName>
                                         <persName xml:lang="per">میرزا محمد صالح
-                                            شیرازی</persName></persName>, son of <persName key="person_f8620"
-                                            ><persName xml:lang="per-Latn-x-lc">Ḥājī Bāqir Khān
+                                            شیرازی</persName></persName>, son of <persName key="person_f8620"><persName xml:lang="per-Latn-x-lc">Ḥājī Bāqir Khān
                                             Kāzarūnī</persName>
                                         <persName xml:lang="per">حاجی باقر خان
-                                        کازرونی</persName></persName>, an associate of <persName
-                                        key="person_44733962">Sir Gore Ouseley</persName>. Note that
+                                        کازرونی</persName></persName>, an associate of <persName key="person_44733962">Sir Gore Ouseley</persName>. Note that
                                     this is different to the better known Safarnāmah of the same
                                     author, which details his travels from Tabriz through the
                                     Caucasus and Western Russia to Europe. </note>
@@ -190,8 +175,7 @@
                             </objectDesc>
 
                             <handDesc>
-                                <handNote scope="major" script="naskh" medium="blackink"
-                                > </handNote>
+                                <handNote scope="major" script="naskh" medium="blackink"> </handNote>
                             </handDesc>
                         </physDesc>
 
@@ -199,10 +183,8 @@
                             
                             <origin>
                                 <origPlace cert="medium">Iran, possible Tehran</origPlace> 
-                                <origDate when="1812-05-23" calendar="#Hijri-qamari"
-                                    >11 Jumādā-yi avval 1227</origDate>
-                                <origDate when="1812-05-23" calendar="#Gregorian"
-                                    >23 May 1812</origDate>
+                                <origDate when="1812-05-23" calendar="#Hijri-qamari">11 Jumādā-yi avval 1227</origDate>
+                                <origDate when="1812-05-23" calendar="#Gregorian">23 May 1812</origDate>
                             </origin>
 
                         </history>
@@ -254,16 +236,12 @@
                                     with some Cyrillic and Latin script equivalents in the
                                     back</textLang>
                                 <note>The title is given as <title xml:lang="eng" type="desc">Adighebja Alif-Beija or The
-                                    Circassian Alphabet</title> on <locus from="43a"
-                                        to="43a">folio 43a</locus> and <title key="" xml:lang="kbd">اىدىگہ‍ىبذہ اىلىف بېیڞېی</title> in the colophon on <locus from="52a"
-                                            to="52a">folio 52a</locus>. The second word of the title (Alifbeija / اىلىف بېیڞېی) does not
+                                    Circassian Alphabet</title> on <locus from="43a" to="43a">folio 43a</locus> and <title key="" xml:lang="kbd">اىدىگہ‍ىبذہ اىلىف بېیڞېی</title> in the colophon on <locus from="52a" to="52a">folio 52a</locus>. The second word of the title (Alifbeija / اىلىف بېیڞېی) does not
                                     correspond to any known word in Kabardian for the Arabic script
                                     (alifba). The author (and perhaps also scribe) is given as
-                                    "Shora Gha Beg Mirza A Kabardian Chief" on <locus from="43a"
-                                        to="43a">folio 43a</locus> in a later hand. The name is
+                                    "Shora Gha Beg Mirza A Kabardian Chief" on <locus from="43a" to="43a">folio 43a</locus> in a later hand. The name is
                                     difficult to trace in that form, but this alphabet looks very
-                                    similar (if not identical) to that proposed by <persName
-                                        xml:lang="rus-Latn-x-lc" key="person_13798002">Shora
+                                    similar (if not identical) to that proposed by <persName xml:lang="rus-Latn-x-lc" key="person_13798002">Shora
                                         Bekmurzovich Nogmov (roughly 1801-1844)</persName>, so the
                                     "Gha" element is likely an error, perhaps some mutation of the
                                     title "Agha" or a misinterpretation of the patronymic formula
@@ -285,8 +263,7 @@
                                 <layoutDesc>
                                     <layout columns="1" ruledLines="12" n="mistara">12 lines per
                                         page on most pages between <locus from="43a" to="52a">folios
-                                            43a-52a</locus>; block text on <locus from="49a"
-                                            to="51a">folios 49a-51a</locus> in one column; other
+                                            43a-52a</locus>; block text on <locus from="49a" to="51a">folios 49a-51a</locus> in one column; other
                                         sections of this text vary between 4 and 6 columns per
                                         page.</layout>
                                 </layoutDesc>
@@ -295,8 +272,7 @@
                             <handDesc>
                                 <handNote scope="major" script="naskh" medium="blackink"> Written in
                                     black ink in a significant modification of the Arabic script
-                                    which nevertheless resembles Naskh. Possibly from the hand of <persName
-                                        xml:lang="rus-Latn-x-lc" key="person_13798002" role="scr" cert="low">Shora
+                                    which nevertheless resembles Naskh. Possibly from the hand of <persName xml:lang="rus-Latn-x-lc" key="person_13798002" role="scr" cert="low">Shora
                                          Nogmov</persName> himself.
                                 </handNote>
                             </handDesc>
@@ -304,14 +280,12 @@
 
                         <history>
 
-                            <origin>Exact place of origin unknown, but a note on <locus from="43a"
-                                    to="43a">folio 43a</locus> states that the manuscript (part) was
+                            <origin>Exact place of origin unknown, but a note on <locus from="43a" to="43a">folio 43a</locus> states that the manuscript (part) was
                                 "given by <persName key="person_f8621" role="fmo" cert="medium">M. J. Mischia [/ Mischin?]</persName> who bought it from Astrakhan". This suggests an
                                 origin in <origPlace cert="medium">either Astrakhan or
                                     Pyatigorsk, Kabardia</origPlace>
                                 <origDate notBefore="1825" calendar="#Gregorian">not before 1825
-                                    when <persName xml:lang="rus-Latn-x-lc" key="person_13798002"
-                                        >Shora Bekmurzovich Nogmov (roughly 1801-1844)</persName>
+                                    when <persName xml:lang="rus-Latn-x-lc" key="person_13798002">Shora Bekmurzovich Nogmov (roughly 1801-1844)</persName>
                                     first proposed this alphabet</origDate>. </origin>
 
                         </history>
@@ -328,8 +302,7 @@
 
                         <msContents>
 
-                            <summary>Indian almanac in Persian for <date calendar="#Hijri-qamari"
-                                    notBefore="1795-07-18" notAfter="1796-06-07">1210
+                            <summary>Indian almanac in Persian for <date calendar="#Hijri-qamari" notBefore="1795-07-18" notAfter="1796-06-07">1210
                                 AH</date></summary>
                             <textLang mainLang="per">Persian</textLang>
 
@@ -339,9 +312,7 @@
                                 <title key="work_23490" xml:lang="eng" type="desc">Persian Ephemerides</title>
                                 <title key="work_23490" xml:lang="eng" type="desc">Persian Almanac</title>
                                 <listBibl>
-                                    <bibl><ref
-                                        target="https://archive.org/details/catalogueofpersi01bodluoft/page/474/mode/2up?view=theater"
-                                        >Sachau, Ed. and Ethé, Hermann. <title>Catalogue of the
+                                    <bibl><ref target="https://archive.org/details/catalogueofpersi01bodluoft/page/474/mode/2up?view=theater">Sachau, Ed. and Ethé, Hermann. <title>Catalogue of the
                                             Persian, Turkish, Hindûstânî and Pushtû Manuscripts
                                             in the Bodleian Library</title>. Oxford: Clarendon
                                         Press. 1889. col. 950 § 1573.</ref></bibl>
@@ -377,10 +348,8 @@
                             
                             <origin>
                                 <origPlace>Greater India</origPlace> 
-                                <origDate calendar="#Hijri-qamari"
-                                    notBefore="1796-06-07">no earlier than the last day of 1210
-                                    AH</origDate> <origDate calendar="#Gregorian"
-                                        notBefore="1796-06-07">7 June 1796</origDate>
+                                <origDate calendar="#Hijri-qamari" notBefore="1796-06-07">no earlier than the last day of 1210
+                                    AH</origDate> <origDate calendar="#Gregorian" notBefore="1796-06-07">7 June 1796</origDate>
                             </origin>
 
                             <provenance>An inscription on <locus from="53a" to="53a">folio 53a</locus> bares the name of <persName key="person_18419237" role="fmo">W. Ouseley</persName>.</provenance>

--- a/collections/oxford university/MS_Ouseley_195.xml
+++ b/collections/oxford university/MS_Ouseley_195.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23173">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23173">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -84,7 +87,7 @@
                         وتسعمایه کتبه حاجی محمد التبریزی </colophon>
                      <note>The text was originally dedicated to the Timurid <persName key="person_77382759" role="dte">Ḥusayn Bāyqarā, Sultan of Khorasan, 1438-1506</persName>.</note>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                               and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                               Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                            Oxford: Clarendon Press. 1930. col. 1199 § (84) 2122.</ref></bibl>
@@ -117,7 +120,7 @@
                         headings within illuminated ‘unwāns. Scribe: A small note at the end of the
                         colophon gives the name of the scribe as <persName role="scr" key="person_f2860"><persName xml:lang="chg">حاجی محمد التبریزی</persName>
                            <persName xml:lang="chg-Latn-x-lc">Ḥājī Muḥammad
-                           al-Tabrīzī</persName></persName>, which <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/pageview/775168">Ethé (1930: 2122)</ref> identifies as an alternate appelation for the
+                           al-Tabrīzī</persName></persName>, which <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=32">Ethé (1930: 2122)</ref> identifies as an alternate appelation for the
                         famous Safavid calligrapher <persName role="scr" key="person_f2860"><persName xml:lang="chg"> محمد حسین تبریزی</persName>
                            <persName xml:lang="chg-Latn-x-lc">Muḥammad Ḥusayn
                            Tabrīzī</persName></persName>.</handNote>
@@ -160,7 +163,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Ouseley_225.xml
+++ b/collections/oxford university/MS_Ouseley_225.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23099">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23099">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -190,7 +193,7 @@
                      <textLang mainLang="ur">Urdu</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775219">Ethé 2346</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=83">Ethé 2346</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Ouseley_94.xml
+++ b/collections/oxford university/MS_Ouseley_94.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_33191">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_33191">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -59,7 +62,7 @@
                      <textLang mainLang="en" otherLangs="ur">English, Urdu</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775218">Ethé 2340</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=82">Ethé 2340</ref>
                         </bibl>
                      </listBibl>
                   </msItem>
@@ -76,7 +79,7 @@
                      <textLang mainLang="ur">Urdu</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775211">Ethé 2312</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=75">Ethé 2312</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Pers_a_2.xml
+++ b/collections/oxford university/MS_Pers_a_2.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22919">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22919">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +61,7 @@
                      <textLang mainLang="fa">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775236">Ethé 2394</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=100">Ethé 2394</ref>
                         </bibl>
                      </listBibl>
                   </msItem>
@@ -68,7 +71,7 @@
                      <textLang mainLang="fa">Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775236">Ethé 2395</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=100">Ethé 2395</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Pococke_15.xml
+++ b/collections/oxford university/MS_Pococke_15.xml
@@ -1,5 +1,8 @@
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
-	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23145">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23145">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -70,7 +73,7 @@
 
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1181 § (46) 2084</ref>

--- a/collections/oxford university/MS_Pococke_22.xml
+++ b/collections/oxford university/MS_Pococke_22.xml
@@ -55,7 +55,7 @@
                                 and a few prose pieces at the end, the whole an entirely useless
                                 compilation.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -90,7 +90,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Pococke_412.xml
+++ b/collections/oxford university/MS_Pococke_412.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23331">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Pococke_412</idno>
@@ -57,9 +58,7 @@
                                 and then interlinear Latin paraphrases, written in pencil. The last
                                 page and a half are altogether in pencil.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -88,17 +87,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_41849535" role="fmo"
-                                >Edward Pococke, d. 1691</persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_41849535" role="fmo">Edward Pococke, d. 1691</persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -106,9 +101,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Pococke_45.xml
+++ b/collections/oxford university/MS_Pococke_45.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23161">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23161">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                             <incipit>(<locus from="1b" to="1b">folio 1b</locus>) حمد بی‌حدّ و ثنای
                                 بی‌عدّ اول حکیم پر حکمت و علیم پر موحبت [...]</incipit>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775164">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=28">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -122,7 +125,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Pococke_94.xml
+++ b/collections/oxford university/MS_Pococke_94.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23255">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Pococke_94</idno>
@@ -80,9 +81,7 @@
                                 by Lāmiʿī himself. An index on the fly-leaves. Copied AH 1024=AD
                                 1615.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=45">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -111,17 +110,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_41849535" role="fmo"
-                                >Edward Pococke, d. 1691</persName>.</provenance>
-                        <acquisition>Purchased by the Bodleian Library in <date
-                                calendar="#Gregorian" when="1692">1692</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_41849535" role="fmo">Edward Pococke, d. 1691</persName>.</provenance>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1692">1692</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -129,9 +124,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Rawl_Or_27.xml
+++ b/collections/oxford university/MS_Rawl_Or_27.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23162">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23162">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -73,7 +76,7 @@
                             <incipit>(<locus from="1b" to="1b">folio 1b</locus>) حمد بی‌حدّ و ثنای
                                 بی‌عدّ اول حکیم پر حکمت و علیم پر موحبت [...]</incipit>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775164">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=28">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -128,7 +131,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Rawl_Or_31.xml
+++ b/collections/oxford university/MS_Rawl_Or_31.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23158">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23158">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -93,7 +96,7 @@
                         reign.</note>
                      <incipit>خافقین و خاتون و وزیرلر قیامته دکن دعایله اکلسار پس شمدی بیزوم شاهمز داخی طوّل الله تعالی عمره و ختم بالخیر امره شمدکیحالده [...]</incipit>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775162">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=26">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1188-1189 § (62)
@@ -142,7 +145,7 @@
 
                   <adminInfo>
                      <recordHist>
-                        <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Rawl_Or_33.xml
+++ b/collections/oxford university/MS_Rawl_Or_33.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23129">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23129">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -78,7 +81,7 @@
                                 Italian</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775153">Ethé 2066</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=17">Ethé 2066</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Rawl_Or_51.xml
+++ b/collections/oxford university/MS_Rawl_Or_51.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23193">
     <teiHeader>
         <fileDesc>
@@ -64,8 +63,7 @@
                     <msContents>
                         
                         <summary>One defective copy of <persName key="person_47178052" role="author">Hamdullah
-                            Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc"
-                                >Leylā vü Mecnūn</title> in Ottoman Turkish.</summary>
+                            Hamdi, 1449-1508</persName>'s <title key="" xml:lang="ota-Latn-x-lc">Leylā vü Mecnūn</title> in Ottoman Turkish.</summary>
                         <textLang mainLang="ota">Ottoman Turkish</textLang>
                         
                         <msItem xml:id="MS_Rawl_Or_51-item1" n="1">
@@ -80,11 +78,9 @@
                             <title key="work_23381" xml:lang="ota-Latn-x-lc">Leylā ve Mecnūn</title>
                             <title key="work_23381" xml:lang="ota-Latn-x-lc">Leylā ü Mecnūn</title>
                             <title key="work_23381" xml:lang="ota">لیلی و مجنون</title>
-                            <incipit></incipit>
+                            <incipit/>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775170"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=34">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1204 § (93) 2131.</ref></bibl>
@@ -122,8 +118,7 @@
                         <provenance>The collections of <persName key="person_44733962" role="fmo">Sir Gore
                             Ouseley, d. 1844</persName></provenance>
                         
-                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian"
-                            when="1858">1858</date>.</acquisition>
+                        <acquisition>Purchased by the Bodleian Library in <date calendar="#Gregorian" when="1858">1858</date>.</acquisition>
                         
                     </history>
                     
@@ -131,9 +126,7 @@
                         
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930.</ref>
@@ -141,8 +134,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of a valid
-                                    reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                                    reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                                         Admissions</ref>). Contact
                                     <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for
                                     further information on the availability of this manuscript</p>

--- a/collections/oxford university/MS_Rawlinson_Or_16.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_16.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23109">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23109">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -57,7 +60,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775149">Ethé 2047</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=13">Ethé 2047</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Rawlinson_Or_17.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_17.xml
@@ -90,7 +90,7 @@
                                 3a. 2. تشخیص امراض انسان و معالجه, on fol. 6a. 3. في النافع, on fol.
                                 16a. 4. في معرفة الترياك, on fol. 20a. No date.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=54">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -125,7 +125,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Rawlinson_Or_18.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_18.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23332">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Rawlinson_Or_18</idno>
@@ -75,9 +76,7 @@
                                 colophon. Beginning: الحمد لله الذي جعل العلماء ورثة الأنبياء و
                                 جعلهم بين عباده المؤمنين الخ. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=62">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -106,17 +105,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_47563478" role="fmo"
-                                >Richard Rawlinson, d. 1755</persName>.</provenance>
-                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date
-                                calendar="#Gregorian" when="1756">1756</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_47563478" role="fmo">Richard Rawlinson, d. 1755</persName>.</provenance>
+                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date calendar="#Gregorian" when="1756">1756</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,9 +119,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Rawlinson_Or_20.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_20.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23121">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23121">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -64,7 +67,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2058</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2058</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Rawlinson_Or_22.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_22.xml
@@ -71,7 +71,7 @@
                                 in ciphers, as officially used, with their equivalents in common
                                 numerical figures.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -81,7 +81,7 @@
                         </msItem>
                         <msItem xml:id="MS_Rawlinson_Or_22-item2" n="2">
                             <title type="desc">İnşā | AH 1073</title>
-                            <title xml:lang="ota"  type="desc">انشاء</title>
+                            <title xml:lang="ota" type="desc">انشاء</title>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -90,7 +90,7 @@
                                 beginning, on fol. 29. At the end, as date, AH 1073 AD
                                 1662/1663.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,7 +108,7 @@
                             <note>Ta'rīḫāt تأریخات or chronograms, on ff. 51b and 52a, relating to
                                 AH 1075-1077, and 1091=AD 1664-1667, and 1680.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -128,7 +128,7 @@
                                 1664/1665), a list of the Turkish Sulṭāns with the dates of their
                                 accession (تواریخ نسل آل عثمان), on fol. 72b, etc.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -163,7 +163,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Rawlinson_Or_3.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_3.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23334">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Rawlinson_Or_3</idno>
@@ -59,9 +60,7 @@
                                 more information.</note>
                             <note>A fragment of Muḫtaṣar der ʿilm-i mūsīḳī. Beginning: كتاب علم موسقى سلطان العلما جامع العلوم الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -90,17 +89,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_47563478" role="fmo"
-                                >Richard Rawlinson, d. 1755</persName>.</provenance>
-                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date
-                                calendar="#Gregorian" when="1756">1756</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_47563478" role="fmo">Richard Rawlinson, d. 1755</persName>.</provenance>
+                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date calendar="#Gregorian" when="1756">1756</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,9 +103,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Rawlinson_Or_32.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_32.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23119">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23119">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -67,7 +70,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2056</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2056</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Rawlinson_Or_36.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_36.xml
@@ -64,7 +64,7 @@
                                 end, on ff. 68b and 69a, some stray verses, sayings of the prophet,
                                 etc. No date.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -99,7 +99,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Rawlinson_Or_5.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_5.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23113">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23113">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -54,7 +57,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775150">Ethé 2050</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=14">Ethé 2050</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Rawlinson_Or_7.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_7.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23335">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Rawlinson_Or_7</idno>
@@ -72,9 +73,7 @@
                                 العبد الضعيف محمد بن يونس الدروازى المشهور الملقب بالمفرد. This copy
                                 is incomplete at the end.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=67">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -105,17 +104,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_47563478" role="fmo"
-                                >Richard Rawlinson, d. 1755</persName>.</provenance>
-                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date
-                                calendar="#Gregorian" when="1756">1756</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_47563478" role="fmo">Richard Rawlinson, d. 1755</persName>.</provenance>
+                        <acquisition>The Rawlinson bequest entered the Bodleian Library in <date calendar="#Gregorian" when="1756">1756</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -123,9 +118,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Rawlinson_Or_8.xml
+++ b/collections/oxford university/MS_Rawlinson_Or_8.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1663">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1663">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -63,7 +66,7 @@
                      </note>
                      <listBibl>
                         <bibl>GAL I 350</bibl>
-                        <bibl><ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775154">Ethé 2070</ref></bibl>
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=18">Ethé 2070</ref></bibl>
                      </listBibl>
                      <textLang mainLang="ar" otherLangs="ota">Arabic, Turkish</textLang>
                   </msItem>

--- a/collections/oxford university/MS_S_Clarke_36.xml
+++ b/collections/oxford university/MS_S_Clarke_36.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23111">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23111">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -65,7 +68,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775149">Ethé 2046</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=13">Ethé 2046</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_30.xml
+++ b/collections/oxford university/MS_Sale_30.xml
@@ -79,7 +79,7 @@
                                 eş-Şāmī, the 25th of Cemāẕī el-evvel, AH 998=AD 1590, April
                                 1.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=36">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -118,7 +118,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Sale_31.xml
+++ b/collections/oxford university/MS_Sale_31.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23260">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Sale_31</idno>
@@ -47,7 +48,7 @@
                             <title key="work_23436" xml:lang="ota-Latn-x-lc">Ṣoḥbetü l-ebkār</title>
                             <title xml:lang="ota" key="work_23436">صحبة الابکار</title>
                             <author key="person_262153759">
-                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb></lb>
+                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde ʿAṭā'ī</persName> <persName xml:lang="ota">نوعی‌زاده عطاٸی</persName>
                             </author>
                             <incipit xml:lang="ota"> ایده لم بسملة هادی راه يوروسون قافلة حمد
@@ -62,9 +63,7 @@
                                 70, last line). Beginning, on fol. 1b: ایده لم بسملة هادی راه
                                 يوروسون قافلة حمد اله. Copied AH 1118=AD 1706.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -77,7 +76,7 @@
                             <title key="work_23437">The cupbearer's book</title>
                             <title xml:lang="ota" key="work_23437">ساقی‌نامه</title>
                             <author key="person_262153759">
-                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb></lb>
+                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde ʿAṭā'ī</persName> <persName xml:lang="ota">نوعی‌زاده عطاٸی</persName>
                             </author>
                             <incipit xml:lang="ota"> بنام خداوند افلاك و خاك برآرنده گوی و چوگان
@@ -94,9 +93,7 @@
                                 و خاك برآرنده گوی و چوگان تاک. Copied in the same year AH 1118,
                                 month of Ṣafer=AD 1706, May-June.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -109,7 +106,7 @@
                             <title xml:lang="ota" key="work_23438">هفتخوان</title>
                             <title key="work_23438">The seven dishes</title>
                             <author key="person_262153759">
-                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb></lb>
+                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde ʿAṭā'ī</persName> <persName xml:lang="ota">نوعی‌زاده عطاٸی</persName>
                             </author>
                             <incipit xml:lang="ota"> نقش پرداز لوح رنگارنگ ای نسق ساز باغ هفت
@@ -122,9 +119,7 @@
                                 that in the first Berlin copy), on fol. 106b: نقش پرداز لوح رنگارنگ
                                 ای نسق ساز باغ هفت اورنگ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -137,7 +132,7 @@
                             <title xml:lang="ota" key="work_23439">نفحة الازهار</title>
                             <title key="work_23439">The odour of flowers</title>
                             <author key="person_262153759">
-                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb></lb>
+                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde ʿAṭā'ī</persName> <persName xml:lang="ota">نوعی‌زاده عطاٸی</persName>
                             </author>
                             <incipit xml:lang="ota"> بسم الله الرّحمن الرّحيم فهرس غرای کتاب
@@ -151,9 +146,7 @@
                                 Beginning, on fol. 163b: بسم الله الرّحمن الرّحيم فهرس غرای کتاب
                                 کریم.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -164,7 +157,7 @@
                         <msItem xml:id="MS_Sale_31-item5" n="5">
                             <title key="work_23440" type="desc">Lyrical poems</title>
                             <author key="person_262153759">
-                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb></lb>
+                                <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde, ʿAṭāʾullāh b. Yaḥyā</persName><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Nevʿīzāde ʿAṭā'ī</persName> <persName xml:lang="ota">نوعی‌زاده عطاٸی</persName>
                             </author>
                             <incipit xml:lang="ota"> بسم الله ... فهرس غراى الخ ... ایلسون بسمله نقش
@@ -183,9 +176,7 @@
                                 order, on fol. 252b; ḳıṭʿas, chronograms, rübāʿīs, and maṭālıʿ, on
                                 fol. 286b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=37">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -217,22 +208,16 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_76658435" role="fmo"
-                                >George Sale, d. <date calendar="#Gregorian" when="1736"
-                                >1736</date></persName>.</provenance>
+                        <provenance>The collections of <persName key="person_76658435" role="fmo">George Sale, d. <date calendar="#Gregorian" when="1736">1736</date></persName>.</provenance>
                         <provenance>Acquired by <persName key="person_32343452" role="fmo">Thomas
-                                Hunt</persName> in <date calendar="#Gregorian" when="1760"
-                                >1760</date>.</provenance>
+                                Hunt</persName> in <date calendar="#Gregorian" when="1760">1760</date>.</provenance>
                         <provenance>The Radcliffe Library.</provenance>
-                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian"
-                                when="1872">1872</date>.</acquisition>
+                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian" when="1872">1872</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -240,9 +225,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Sale_33.xml
+++ b/collections/oxford university/MS_Sale_33.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23194">
     <teiHeader>
         <fileDesc>
@@ -76,9 +75,7 @@
                             <title key="work_23379" xml:lang="ota">محبت‌نامه</title>
                             <incipit>سپاس و شکر اول یزدان پاکه <lb/> که اولدر جان ویرن بو مشت خاکه</incipit>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775170"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=34">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1204-1205 § (94) 2132.</ref></bibl>
@@ -92,9 +89,7 @@
                             <title key="work_23380" xml:lang="ota-Latn-x-lc">Ta'rīḫ-i köşk-i Sinān Paşa</title>
                             <title key="work_23380" xml:lang="ota">تأریخ کوشك سنان پاشا</title>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775171"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=35">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1205 § (94) 2132.</ref></bibl>
@@ -127,21 +122,16 @@
                         
                         <origin>
                             Place of origin unknown. Given the date on the chronogram, penned 
-                            <origDate notBefore="1591" calendar="#Hijri-qamari"
-                                >no earlier than 999</origDate>
-                            <origDate notBefore="1591" calendar="#Gregorian"
-                                >1591</origDate>.
+                            <origDate notBefore="1591" calendar="#Hijri-qamari">no earlier than 999</origDate>
+                            <origDate notBefore="1591" calendar="#Gregorian">1591</origDate>.
                         </origin>
                         
                         <provenance>The collections of <persName key="person_76658435" role="fmo">George
-                            Sale, d. <date calendar="#Gregorian" when="1736"
-                                >1736</date></persName>.</provenance>
+                            Sale, d. <date calendar="#Gregorian" when="1736">1736</date></persName>.</provenance>
                         <provenance>Acquired by <persName key="person_32343452" role="fmo">Thomas
-                            Hunt</persName> in <date calendar="#Gregorian" when="1760"
-                                >1760</date>.</provenance>
+                            Hunt</persName> in <date calendar="#Gregorian" when="1760">1760</date>.</provenance>
                         <provenance>The Radcliffe Library.</provenance>
-                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian"
-                            when="1872">1872</date>.</acquisition>
+                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian" when="1872">1872</date>.</acquisition>
                         
                     </history>
                     
@@ -149,10 +139,7 @@
                         
                         <adminInfo>
                             <recordHist>
-                                <source> Description written by <persName role="cataloguer" ref="http://viaf.org/viaf/311784694"
-                                    key="person_311784694">Kontovas, Nicholas</persName> based on <ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <source> Description written by <persName role="cataloguer" ref="http://viaf.org/viaf/311784694" key="person_311784694">Kontovas, Nicholas</persName> based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930.</ref>
@@ -160,8 +147,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of a valid
-                                    reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
+                                    reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian
                                         Admissions</ref>). Contact
                                     <email>specialcollections.enquiries@bodleian.ox.ac.uk</email> for
                                     further information on the availability of this manuscript</p>

--- a/collections/oxford university/MS_Sale_37.xml
+++ b/collections/oxford university/MS_Sale_37.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23164">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23164">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -78,7 +81,7 @@
                                         Süleymān</persName></persName> (i.e. <persName key="person_89743257" role="dte">Süleyman‏ ,‏Sultan of
                                 the Turks, d. 1494 or 1495-1566</persName>).</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775164">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=28">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -139,7 +142,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Sale_39.xml
+++ b/collections/oxford university/MS_Sale_39.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23038">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23038">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -59,7 +62,7 @@
                         müştemil ‘alā ḥikāyāt-i ġarībe ve ümūr-ı ‘acībe</title>
                      <title xml:lang="per-Latn-x-lc" key="work_21485">Iskandarnāmah-ʼi laṭīf
                         mushtamil ʻalá ḥikāyāt gharībah wa-umūr ʻajībah</title>
-                     <note><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775164">Ethé (1930: col. 1193)</ref> notes many lacunae in the text, and
+                     <note><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=28">Ethé (1930: col. 1193)</ref> notes many lacunae in the text, and
                         suggests that this is only half of a larger work of which the rest has been
                         lost.</note>
                      <incipit>بعد از حمد خدای ذی الجلال ​​* میتواند بر زبان ما مجال * باد بی‌حد و
@@ -68,7 +71,7 @@
                         Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775164">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=28">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1192-1193 § (68) 2106.</ref>

--- a/collections/oxford university/MS_Sale_4.xml
+++ b/collections/oxford university/MS_Sale_4.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23336">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Sale_4</idno>
@@ -82,9 +83,7 @@
                                 فضل ارتق اتدى على جميع الألسن جميع دللر اوزينه لسان العرب عرب دلني
                                 الخ. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=56">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -96,8 +95,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>123 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>123 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara" ruledLines="43">1 column of 43 lines
@@ -111,22 +109,16 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_76658435" role="fmo"
-                                >George Sale, d. <date calendar="#Gregorian" when="1736"
-                                >1736</date></persName>.</provenance>
+                        <provenance>The collections of <persName key="person_76658435" role="fmo">George Sale, d. <date calendar="#Gregorian" when="1736">1736</date></persName>.</provenance>
                         <provenance>Acquired by <persName key="person_32343452" role="fmo">Thomas
-                                Hunt</persName> in <date calendar="#Gregorian" when="1760"
-                                >1760</date>.</provenance>
+                                Hunt</persName> in <date calendar="#Gregorian" when="1760">1760</date>.</provenance>
                         <provenance>The Radcliffe Library.</provenance>
-                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian"
-                                when="1872">1872</date>.</acquisition>
+                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian" when="1872">1872</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -134,9 +126,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Sale_46.xml
+++ b/collections/oxford university/MS_Sale_46.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23149">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23149">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +84,7 @@
                            Bodleian Libraries, Special Collections, Asian and Middle Eastern
                            Manuscripts, MS. Clarke 10</ref>.</filiation>
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1185 § (52) 2090.</ref></bibl>
@@ -140,7 +143,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Sale_50.xml
+++ b/collections/oxford university/MS_Sale_50.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23135">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23135">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -64,7 +67,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Sale_60.xml
+++ b/collections/oxford university/MS_Sale_60.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23122">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23122">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -62,7 +65,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2059</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2059</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_61.xml
+++ b/collections/oxford university/MS_Sale_61.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23105">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23105">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -62,7 +65,7 @@
                      <textLang mainLang="ota">Ottoman Turkish</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775148">Ethé 2044</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=12">Ethé 2044</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Sale_62.xml
+++ b/collections/oxford university/MS_Sale_62.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23106">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23106">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -57,7 +60,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775148">Ethé 2042</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=12">Ethé 2042</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_63.xml
+++ b/collections/oxford university/MS_Sale_63.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23107">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23107">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -59,7 +62,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775148">Ethé 2043</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=12">Ethé 2043</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_64.xml
+++ b/collections/oxford university/MS_Sale_64.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23110">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23110">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775149">Ethé 2048</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=13">Ethé 2048</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_65.xml
+++ b/collections/oxford university/MS_Sale_65.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23134">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23134">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -68,7 +71,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Sale_66.xml
+++ b/collections/oxford university/MS_Sale_66.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23117">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23117">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -63,7 +66,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775151">Ethé 2054</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=15">Ethé 2054</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Sale_67.xml
+++ b/collections/oxford university/MS_Sale_67.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23144">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23144">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -69,7 +72,7 @@
                         قلندقدن صکره ضمایر ارباب عرفانه خقی و نهان و کلدر</incipit>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1180-1181 § (45) 2083</ref>

--- a/collections/oxford university/MS_Sale_67a.xml
+++ b/collections/oxford university/MS_Sale_67a.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1708">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1708">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -79,7 +82,7 @@
                                 بی‌قیاس ومنتهای بی‌منتهای الاساس</incipit>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775154">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=18">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Sale_69.xml
+++ b/collections/oxford university/MS_Sale_69.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23261">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Sale_69</idno>
@@ -68,9 +69,7 @@
                                 الفوائد (see the preface in the preceding copy). Dated in the month
                                 Rebīʿü l-āḫir, AH 963 = AD 1556, Febr./March.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=51">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -123,9 +122,7 @@
                                 بیاننده; the twenty-sixth bāb is found on fol. 68b. Dated Receb, A.
                                 H. 963=A. D. 1556, May-June.</note>
                             <listBibl>
-                                <bibl><ref
-                                    target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                    >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=66">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                         Hindûstânî and Pushtû Manuscripts in the Bodleian
                                         Library, Part II: Turkish, Hindûstânî, Pushtû and
                                         Additional Persian Manuscripts</title>. Oxford:
@@ -153,25 +150,17 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" when="1556"
-                                >963</origDate><origDate calendar="#Gregorian" when="1556"
-                                >1556</origDate></origin>
-                        <provenance>The collections of <persName key="person_76658435" role="fmo"
-                                >George Sale, d. <date calendar="#Gregorian" when="1736"
-                                >1736</date></persName>.</provenance>
+                        <origin><origDate calendar="#Hijri-qamari" when="1556">963</origDate><origDate calendar="#Gregorian" when="1556">1556</origDate></origin>
+                        <provenance>The collections of <persName key="person_76658435" role="fmo">George Sale, d. <date calendar="#Gregorian" when="1736">1736</date></persName>.</provenance>
                         <provenance>Acquired by <persName key="person_32343452" role="fmo">Thomas
-                                Hunt</persName> in <date calendar="#Gregorian" when="1760"
-                                >1760</date>.</provenance>
+                                Hunt</persName> in <date calendar="#Gregorian" when="1760">1760</date>.</provenance>
                         <provenance>The Radcliffe Library.</provenance>
-                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian"
-                                when="1872">1872</date>.</acquisition>
+                        <acquisition>Acquired by the Bodleian Library in <date calendar="#Gregorian" when="1872">1872</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -179,9 +168,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Sale_77.xml
+++ b/collections/oxford university/MS_Sale_77.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23132">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23132">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -50,13 +53,13 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
                                         Clarendon Press. 1930. p. 1173 § (33) 2071</ref>
                                 </bibl>
-                                <bibl> For a possible other witness of the same text, see <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/pageview/799430">Pertsch, Wilhelm. <title> Die orientalischen Handschriften
+                                <bibl> For a possible other witness of the same text, see <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=24294">Pertsch, Wilhelm. <title> Die orientalischen Handschriften
                                             der Herzoglichen Bibliothek zu Gotha / Auf Befehl Sr.
                                             Hoheit des Herzogs Ernst II. von S. Coburg-Gotha, Theil
                                             2: Die türkischen Handschriften der Herzoglichen
@@ -99,7 +102,7 @@
                                 حضرتنه کی اون سکز بیک عالمی </incipit>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Savile_50.xml
+++ b/collections/oxford university/MS_Savile_50.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23338">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Savile_50</idno>
@@ -74,9 +75,7 @@
                                 واياغله..., corresponding to Laud Or. 125 (No. 1697 above), fol. 15,
                                 1. 5 ab infra.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=57">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -111,9 +110,7 @@
                                 Roman characters, both interlinear and marginal, and a few English
                                 paraphrases, made in pencil. Copied A. H. 1030=A. D. 1621.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=57">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -149,9 +146,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -159,9 +154,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_20.xml
+++ b/collections/oxford university/MS_Selden_Superius_20.xml
@@ -67,7 +67,7 @@
                                 pages; on fol. 9b, besides, an اشتیاج‌نامه and a نوع دیگر اشتیاق
                                 نامه (two specimens of love-letters).</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=48">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -102,7 +102,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Selden_Superius_35.xml
+++ b/collections/oxford university/MS_Selden_Superius_35.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23267">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_35</idno>
@@ -46,9 +47,7 @@
                         <msItem xml:id="MS_Selden_Superius_35-item1" n="1">
                             <title key="work_23442" xml:lang="ota-Latn-x-lc">Mers̠iyāt</title>
                             <title key="work_23442" xml:lang="ota">مرثیات</title>
-                            <author key="person_78903177"><persName xml:lang="ota-Latn-x-lc"
-                                >ʿAbdürraḥmān Ġubārī</persName> <persName xml:lang="ota"
-                                    >عبد الرحمن غباری</persName></author>
+                            <author key="person_78903177"><persName xml:lang="ota-Latn-x-lc">ʿAbdürraḥmān Ġubārī</persName> <persName xml:lang="ota">عبد الرحمن غباری</persName></author>
                             <incipit> بر کجه ساکن ایدم خانقه عزلتده الخ</incipit>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
@@ -76,9 +75,7 @@
                                 1592, and AH 1026=AD 1617 respectively, ib. iii. pp. 10, 78, and
                                 164), on fol. 103a; and Su'ālī, on fol. 103b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,8 +86,7 @@
                         <msItem xml:id="MS_Selden_Superius_35-item2" n="2">
                             <title key="work_23443">Taḫmīsāt ve muḫammesāt</title>
                             <title key="work_23443" xml:lang="ota">تخمیسات و مخمسات</title>
-                            <author key="person_261750298"><persName xml:lang="ota-Latn-x-lc"
-                                >Necātī Beg, d. 1509</persName></author>
+                            <author key="person_261750298"><persName xml:lang="ota-Latn-x-lc">Necātī Beg, d. 1509</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -112,9 +108,7 @@
                                 Süleymān I and Selīm II, AH 926-982=AD 1520-1574, see Rieu, pp. 179b
                                 and 180a), on fol. 109a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -125,9 +119,7 @@
                         <msItem xml:id="MS_Selden_Superius_35-item3" n="3">
                             <title key="work_23444">Murabba'āt</title>
                             <title key="work_23444" xml:lang="ota">مربعات</title>
-                            <author key="person_248424574"><persName xml:lang="ota-Latn-x-lc"
-                                >ʿAbdürraḥmān ʿUbeydī, -1572 or 1573</persName> <persName xml:lang="ota"
-                                    >عبد الرحمن عبیدی</persName></author>
+                            <author key="person_248424574"><persName xml:lang="ota-Latn-x-lc">ʿAbdürraḥmān ʿUbeydī, -1572 or 1573</persName> <persName xml:lang="ota">عبد الرحمن عبیدی</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -153,9 +145,7 @@
                                 1538/1539, see Hammer, Osman. Dichtkunst, ii. p. 222), and
                                 Resmī.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -172,9 +162,7 @@
                                 more information.</note>
                             <note>Muʿammās or riddles, on fol. 119b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -212,9 +200,7 @@
                                 see above); AH 961=AD 1554; AH 962= AD 1555, on the death of Sinān
                                 Paşa; AH 964 =AD 1557; and AH 966=AD 1558/1559.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -227,9 +213,7 @@
                             <title key="work_23447" xml:lang="ota">غزللر</title>
                             <incipit xml:lang="ota"> اول الف قد چورادر که اتمز تحمّل قاف آگا کورمدم
                                 آنگ کبی انصافسز انصاف اگا</incipit>
-                            <author key="person_42678600"><persName xml:lang="ota-Latn-x-lc"
-                                >Ẕātī (d 953/1546-7)</persName><persName xml:lang="ota"
-                                >ذاتی</persName></author>
+                            <author key="person_42678600"><persName xml:lang="ota-Latn-x-lc">Ẕātī (d 953/1546-7)</persName><persName xml:lang="ota">ذاتی</persName></author>
                             <note>NOTE: This record has been automatically generated with minimal
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
@@ -242,9 +226,7 @@
                                 fol. 147b a murabbaʿ and a ḳıṭʿa, and on that of fol. 148a a ġazel
                                 by Ḫayālī Beg.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=39">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -265,9 +247,7 @@
                             <author><persName xml:lang="ota-Latn-x-lc">Āgāhī</persName></author>
                             <author><persName xml:lang="ota-Latn-x-lc">Selāmī</persName></author>
                             <author key="person_317282511"><persName xml:lang="ota-Latn-x-lc">Ḫayālī</persName></author>
-                            <author key="person_248424574"><persName xml:lang="ota-Latn-x-lc"
-                                >ʿAbdürraḥmān ʿUbeydī, -1572 or 1573</persName> <persName xml:lang="ota"
-                                    >عبد الرحمن عبیدی</persName></author>
+                            <author key="person_248424574"><persName xml:lang="ota-Latn-x-lc">ʿAbdürraḥmān ʿUbeydī, -1572 or 1573</persName> <persName xml:lang="ota">عبد الرحمن عبیدی</persName></author>
                             <author key="person_68483252">
                                 <persName xml:lang="ota-Latn-x-lc">Sürūrī, Muṣliḥ al-Dīn, 1492-1562</persName>
                             </author>
@@ -346,9 +326,7 @@
                                 Ḥāletī, who died AH 1040=AD 1630/1631, Rieu, ib. and p. 186a), on
                                 fol. 86b; and Seyfī, on fol. 87a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=40">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -378,17 +356,13 @@
                     <history>
                         <origin>unknown</origin>
                         <provenance>Previously owned by one <persName role="fmo" key="person_f8520"><persName xml:lang="ota-Latn-x-lc">Muḥammed bin Ḥüseyn aṭ-Ṭabbāḫ</persName> <persName xml:lang="ota">محمد بن حسین الطباخ</persName></persName></provenance>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -396,9 +370,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_38.xml
+++ b/collections/oxford university/MS_Selden_Superius_38.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23269">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_38</idno>
@@ -67,9 +68,7 @@
                                 off on fol. 22b in the beginning of the eleventh bāb; ff. 23 and 24
                                 are left blank.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=52">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -107,9 +106,7 @@
                                 character as the هدية الطلاب, a fragment of which is noticed in
                                 Rieu, p. 122.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=52">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -138,17 +135,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -156,9 +149,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_45.xml
+++ b/collections/oxford university/MS_Selden_Superius_45.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23346">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_45</idno>
@@ -63,9 +64,7 @@
                                 English notes in this manuscript prove that it dates from 1628 and
                                 1629.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=59">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -90,17 +89,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -108,9 +103,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_68.xml
+++ b/collections/oxford university/MS_Selden_Superius_68.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23270">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_68</idno>
@@ -106,9 +107,7 @@
                                 was transcribed from a manuscript, copied directly from the author's
                                 autograph.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=53">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -156,9 +155,7 @@
                                 on fol 87b, a ثالثة ثانية, and رابعه. Copied by the same transcriber
                                 as the preceding treatise.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=53">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -186,20 +183,14 @@
                         </handDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate calendar="#Hijri-qamari" when="1571"
-                                >978</origDate><origDate calendar="#Gregorian" when="1571"
-                                >1571</origDate></origin>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <origin><origDate calendar="#Hijri-qamari" when="1571">978</origDate><origDate calendar="#Gregorian" when="1571">1571</origDate></origin>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -207,9 +198,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_7.xml
+++ b/collections/oxford university/MS_Selden_Superius_7.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23347">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_7</idno>
@@ -52,9 +53,7 @@
                                 more information.</note>
                             <note>Without a taḫalluṣ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -79,17 +78,13 @@
                     </physDesc>
                     <history>
                         <origin>unknown</origin>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,9 +92,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_74.xml
+++ b/collections/oxford university/MS_Selden_Superius_74.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23348">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Selden_Superius_74</idno>
@@ -61,9 +62,7 @@
                                 the preceding läll älg. It begins with هشتنه and ends with the first
                                 infinitive, يرتق = آفريدن.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=57">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -100,9 +99,7 @@
                                 technical name of the metre and one or two Turkish beyts as
                                 example. Copied A. H. 1023= A. D. 1614, at Constantinople.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=57">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -114,8 +111,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>5 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>5 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara" ruledLines="7">1 column of 7 lines
@@ -133,17 +129,13 @@
                             <origDate calendar="#Gregorian" when="1614">1614</origDate>
                             <origDate calendar="#Hijri-qamari" when="1614">1023</origDate>
                         </origin>
-                        <provenance>The collections of <persName key="person_51728429" role="fmo"
-                                >John Selden</persName>.</provenance>
-                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date
-                                calendar="#Gregorian" when="1659">1659</date>.</acquisition>
+                        <provenance>The collections of <persName key="person_51728429" role="fmo">John Selden</persName>.</provenance>
+                        <acquisition>Presented to the Bodleian Library by Selden's estate in <date calendar="#Gregorian" when="1659">1659</date>.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -151,9 +143,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Selden_Superius_8.xml
+++ b/collections/oxford university/MS_Selden_Superius_8.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23154">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23154">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +77,7 @@
                            Or. 85</ref>. </filiation>
 
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775162">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=26">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1187 § (56) 2095.</ref></bibl>
@@ -126,7 +129,7 @@
                      <recordHist>
                         <source>
                            <listBibl>
-                              <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                              <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                        Hindûstânî and Pushtû Manuscripts in the Bodleian Library,
                                        Part II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                        Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Selden_Superius_95.xml
+++ b/collections/oxford university/MS_Selden_Superius_95.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5070">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5070">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -110,7 +113,7 @@
                                         1336-1405</persName></persName>.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -161,7 +164,7 @@
                                     al-saʻdayn wa-majmaʻ al-baḥrayn</title>.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -184,7 +187,7 @@
                                 </persName>.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -210,7 +213,7 @@
                                 </persName>.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775155">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=19">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -230,7 +233,7 @@
                                         1336-1405</persName></persName>.</note>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775156">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=20">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Selden_superius_1.xml
+++ b/collections/oxford university/MS_Selden_superius_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23046">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23046">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                      <textLang mainLang="ota" otherLangs="fa">Ottoman Turkish, Persian</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775178">Ethé 2158</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=42">Ethé 2158</ref>
                         </bibl>
                      </listBibl>
                   </msItem>

--- a/collections/oxford university/MS_Selden_superius_37.xml
+++ b/collections/oxford university/MS_Selden_superius_37.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23179">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23179">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -79,7 +82,7 @@
                                 حَقیٕچُون نِیَتْ اِتْدُمْ حَقَّه هَرْ دَمْ تَمَامْ اِتْدُمْ سُوزيٕ وَاللَّهِ اَعْلَمْ
                             </explicit>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775180">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=44">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1223 § (129) 2167.</ref></bibl>
@@ -101,7 +104,7 @@
                                 دُو حَدِ إِقْبَالُڭ اُولسُون رُوزِ شَبْ سَرْ سَبْز وُ تَرْ وِرْدوکِنْجَه قِیش وُ یَازْ اَحْجَادِ لَعْل اَسْجَادْ کُلْ
                             </explicit>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1193 § (69) 2107.</ref></bibl>
@@ -139,7 +142,7 @@
                             <title key="work_23352" type="desc">sayings and advice of the Prophet</title>
                             <incipit>بسم الله الرحمن الرحیم</incipit>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775165">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=29">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930. col. 1193 § (69) 2107.</ref></bibl>
@@ -194,7 +197,7 @@
                         
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                         and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                         Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                                     Oxford: Clarendon Press. 1930.</ref>

--- a/collections/oxford university/MS_Tanner_Or_384.xml
+++ b/collections/oxford university/MS_Tanner_Or_384.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23446">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Tanner_Or_384</idno>
@@ -52,9 +53,7 @@
                             <note>This item appears with the incorrect shelfmark "Bodl. Or. 103" in
                                 Ethé 2198.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=50">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,9 +82,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -93,9 +90,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_21.xml
+++ b/collections/oxford university/MS_Thurston_21.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23447">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_21</idno>
@@ -71,9 +72,7 @@
                                 etc. Copied in Ẕī l-ḳaʿde, AH 1052=AD 1643, Jan./Feb., by Muḥammed
                                 bin ʿAbdüllāh.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=46">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -85,8 +84,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>17 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>17 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara" ruledLines="11">1 column of 11 lines
@@ -102,17 +100,13 @@
                         <origin>Place of origin unknown. <origDate calendar="#Hijri-qamari" notBefore="1643-01-15" notAfter="1643-02-15">Ẕī l-ḳaʿde 1052</origDate> <origDate calendar="#Gregorian" notBefore="1643-01-15" notAfter="1643-02-15">January/February 1643.</origDate></origin>
                         <provenance>Provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -120,9 +114,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_23.xml
+++ b/collections/oxford university/MS_Thurston_23.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23274">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_23</idno>
@@ -71,7 +72,7 @@
                             <author key="person_f8529"><persName xml:lang="ota-Latn-x-lc">Şemʿ</persName> <persName xml:lang="ota">شمع</persName></author>
                             <author key="person_f8530"><persName xml:lang="ota-Latn-x-lc">Ṭabʿī</persName> <persName xml:lang="ota">طبعی</persName></author>
                             <author key="person_71024513">
-                                <persName xml:lang="ota-Latn-x-lc">Beyânî, -1597</persName> <persName xml:lang="ota"></persName><lb/>
+                                <persName xml:lang="ota-Latn-x-lc">Beyânî, -1597</persName> <persName xml:lang="ota"/><lb/>
                                 <persName xml:lang="ota-Latn-x-lc">Ruscuḳlu Cārullāhzāde Muṣṭafā Beyānī</persName> <persName xml:lang="ota">روسجقلو جار الله زاده مصطفی بیانی</persName>
                             </author>
                             <author key="person_f8531">
@@ -166,9 +167,7 @@
                                 a Persian ġazel appears, for instance, by Saʿdī and others. Ff. 4-7
                                 are turned upside down. This copy is defective at the end.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=41">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -180,8 +179,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>90 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>90 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="2" n="mistara" ruledLines="10">2 columns of 10
@@ -197,17 +195,13 @@
                         <origin>unknown</origin>
                         <provenance>Provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -215,9 +209,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_24.xml
+++ b/collections/oxford university/MS_Thurston_24.xml
@@ -58,7 +58,7 @@
                             <note>The same calendar, agreeing both in beginning and contents with
                                 the preceding copy.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -91,7 +91,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Thurston_26.xml
+++ b/collections/oxford university/MS_Thurston_26.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23350">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_26</idno>
@@ -84,9 +85,7 @@
                                 محمد عليه الصلوة والسلام الخ. Dated A. H. 1088=A. D. 1677/1678, by
                                 Velī bin ʿAbdülkerīm.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -113,9 +112,7 @@
                                 beginning of Ẕī l-ḥicce, A. H. 1088=A. D. 1678, end of
                                 January.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=61">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -137,9 +134,7 @@
                                 and تفسیر فاتحه شريف, a Turkish commentary on the first sūra of the
                                 Qur'ān, on fol. 79a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=61">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -173,17 +168,13 @@
                         </origin>
                         <provenance>Provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -191,9 +182,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_27.xml
+++ b/collections/oxford university/MS_Thurston_27.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23147">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23147">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -70,7 +73,7 @@
                      <title key="work_23241" xml:lang="ota">سیرت سید بطال</title>
                      
                      <listBibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775158">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=22">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. col. 1182 § (49) 2087.</ref></bibl>
@@ -125,7 +128,7 @@
                   <adminInfo>
                      <recordHist>
                         <source>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                     Hindûstânî and Pushtû Manuscripts in the Bodleian Library, Part
                                     II: Turkish, Hindûstânî, Pushtû and Additional Persian
                                     Manuscripts</title>. Oxford: Clarendon Press.

--- a/collections/oxford university/MS_Thurston_28.xml
+++ b/collections/oxford university/MS_Thurston_28.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23276">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_28</idno>
@@ -80,9 +81,7 @@
                                 who is mentioned in Rieu, p. 82b, as having lived about A. H.-902=AD
                                 1496/1497.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=43">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -114,17 +113,13 @@
                         <provenance>An ownership note indicates that this copy once belonged to a certain <persName key="person_f8544" role="fmo"><persName xml:lang="ota-Latn-x-lc">Yaḥyā bin İdrīs</persName> <persName xml:lang="ota">یحیی بن ادریس</persName></persName>.</provenance>
                         <provenance>Immediate provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -132,9 +127,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_30.xml
+++ b/collections/oxford university/MS_Thurston_30.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23277">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_30</idno>
@@ -68,7 +69,7 @@
                             <author key="person_f8528"><persName xml:lang="ota-Latn-x-lc">ʿUbeydī</persName> <persName xml:lang="ota">عبیدی</persName></author>
                             <author key="person_88709578"><persName xml:lang="ota-Latn-x-lc">Bāḳī</persName> <persName xml:lang="ota">باقی</persName></author>
                             <author key="person_22198747">
-                                <persName>Alisher Navoiĭ, 1441-1501</persName> <lb></lb>
+                                <persName>Alisher Navoiĭ, 1441-1501</persName> <lb/>
                                 <persName xml:lang="chg-Latn-x">Niżāmuddīn Mīr ‘Alīšēr Nawā'ī
                                     Harawī</persName> <persName xml:lang="chg">نظام‌الدین میر علی‌شیر نواٸی هروی</persName>
                             </author>
@@ -96,9 +97,7 @@
                                 48a sq. long extracts from the باب الافراط في العشق , and a great
                                 number of تورکی or popular songs.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=41">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -131,17 +130,13 @@
                         <origin>unknown</origin>
                         <provenance>Provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -149,9 +144,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_34.xml
+++ b/collections/oxford university/MS_Thurston_34.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23353">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Thurston_34</idno>
@@ -63,13 +64,10 @@
                                 may contain errors. Please, consult the References section below for
                                 more information.</note>
                             <note>No date.</note>
-                            <note>May or may not be partially or entirely the same as <ref
-                                    target="https://www.fihrist.org.uk/catalog/work_3560">Risālah fī
+                            <note>May or may not be partially or entirely the same as <ref target="https://www.fihrist.org.uk/catalog/work_3560">Risālah fī
                                 dam al-ḥayḍ wa-aḥkāmihi</ref> and/or <ref target="https://www.fihrist.org.uk/catalog/work_840">Rasāʼil-i Birgivī</ref>.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=60">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -100,17 +98,13 @@
                         <origin>unknown</origin>
                         <provenance>Provenance unknown but not given by Thurston [see Summary
                             Catalogue, 2.ii, 798-801].</provenance>
-                        <acquisition>Presented to the Bodleian Library in <date
-                            calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340"
-                                role="fmo dnr">William Thurston, a merchant of London</persName>, in
+                        <acquisition>Presented to the Bodleian Library in <date calendar="#Gregorian" when="1661">1661</date> by <persName key="person_f8340" role="fmo dnr">William Thurston, a merchant of London</persName>, in
                             1661.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -118,9 +112,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Thurston_39.xml
+++ b/collections/oxford university/MS_Thurston_39.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1815">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1815">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -51,12 +54,9 @@
                                 modification from the corresponding entry in a printed catalogue. It
                                 may contain errors. Please, consult the References section below for
                                 more information.</note>
-                            <note>First Sūrah (سورة الفاتحة) of <title key="work_112"
-                                    >al-Qur'ān</title> on fol. 1b.</note>
+                            <note>First Sūrah (سورة الفاتحة) of <title key="work_112">al-Qur'ān</title> on fol. 1b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -74,9 +74,7 @@
                                 more information.</note>
                             <note>مرة سلیمان on fol. 2a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,9 +92,7 @@
                                 more information.</note>
                             <note>قدح دعاسنڭ شرحی on fol. 3a (different from No. 16 in 2260).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,9 +111,7 @@
                             <note>دعاء قدح on fol. 14a (upon the whole agreeing with No. 17 in
                                 2260).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -136,9 +130,7 @@
                             <note>شرح دعاء دولت on fol 21b (identical with No. 34 in 2260, but
                                 slightly different in wording from No. 1 in 2260).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -156,9 +148,7 @@
                                 more information.</note>
                             <note>دعاء دولت on fol. 44a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -176,9 +166,7 @@
                                 more information.</note>
                             <note>شرح دعاء شريف on fol. 68b (different from No. 14 in 2260).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -196,9 +184,7 @@
                                 more information.</note>
                             <note>دعاء شريف on fol. 75b (wrongly labeled شرح دعاء شريف).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -217,9 +203,7 @@
                                 more information.</note>
                             <note>Some talismans (طلمسات) on fol. 85a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -237,9 +221,7 @@
                                 more information.</note>
                             <note>شرح دعاء ایمان on fol. 87b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -257,9 +239,7 @@
                                 more information.</note>
                             <note>دعاء ایمان on fol. 88b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -278,9 +258,7 @@
                             <note>شرح دعاء اسم اعظم on fol. 90a (identical with No. 32 in
                                 2260).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -298,9 +276,7 @@
                                 more information.</note>
                             <note>دعاء اسم اعظم on fol. 99b, last line.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -318,9 +294,7 @@
                                 more information.</note>
                             <note>دعاء اون آیت on fol. 101b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -338,9 +312,7 @@
                                 more information.</note>
                             <note>شرح دعاء مرجان on fol. 106b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -358,9 +330,7 @@
                                 more information.</note>
                             <note>دعاء مرجان on fol. 119b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -377,9 +347,7 @@
                                 more information.</note>
                             <note>Prayers without special headings on fol. 122b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -398,9 +366,7 @@
                                 more information.</note>
                             <note>شرح دعاء عهد نامه on fol. 136b.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -418,9 +384,7 @@
                                 more information.</note>
                             <note>دعاء عهد نامه on fol. 141b. last line.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -438,9 +402,7 @@
                                 more information.</note>
                             <note>شرح دعاء حروف on fol. 143a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -458,9 +420,7 @@
                                 more information.</note>
                             <note>دعاء حروف on fol 144a.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -481,9 +441,7 @@
                                <bibl>Appendix Prayers</bibl>
                                <bibl>[UAM. 173]</bibl>
                                <bibl>[Uri Turk. 85]</bibl>
-                               <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                               <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=63">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_C_2.xml
+++ b/collections/oxford university/MS_Turk_C_2.xml
@@ -62,7 +62,7 @@
                                 notes and letters, written mostly in AH 1161-1163 AD
                                 1748-1750.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=47">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -97,7 +97,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_F_1.xml
+++ b/collections/oxford university/MS_Turk_F_1.xml
@@ -59,7 +59,7 @@
                             <note>A neatly illuminated copy. Presented by W. Raye, former English
                                 consul in Smyrna, Dec. 30, 1704.</note>
                             <listBibl>
-                                <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=49">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -88,7 +88,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_a_1.xml
+++ b/collections/oxford university/MS_Turk_a_1.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23320">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_a_1_(r)</idno>
@@ -54,9 +55,7 @@
                             <note>Firmān, dated Constantinople, 1st of Muḥarrem, A. H. 1014=A. D.
                                 1605, May 19.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -73,9 +72,7 @@
                             <note>Firmān, dated Constantinople, end of Ṣafer, A. H. 1028=A. D. 1619,
                                 middle of Febr.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -92,9 +89,7 @@
                             <note>Firmān, dated Constantinople, 1st of Ṣafer, A. H. 1039=A. D. 1629,
                                 Sept. 20.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -111,9 +106,7 @@
                             <note>Firmān, dated Constantinople, 9th of Muḥarrem, A. H. 1049 A. D.
                                 1639, May 12.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -130,9 +123,7 @@
                             <note>Firmān, dated Constantinople, 1st of Muḥarrem, A. H. 1066 A. D.
                                 1655, Oct. 31.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -150,9 +141,7 @@
                             <note>Firmān, dated Constantinople, in Şevvāl, A. H. 1077 A. D. 1667,
                                 April, and presented by Rev. H. O. Daniel, March 27, 1888.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -171,9 +160,7 @@
                                 etc., is (Jacob, i. e. James II), defective at the end. No
                                 date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -192,9 +179,7 @@
                                 of England (i. e. George I); it begins exactly like the letter
                                 mentioned in W. Pertsch, Berlin Cat., p. 481.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -211,9 +196,7 @@
                             <note>Firmān sent to the beglerbegi of Egypt, Sinān Paşa, not to suffer
                                 the French to meddle with the English. No date.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -233,9 +216,7 @@
                                 dated A. H. 1187 (A. D. 1773). It belonged formerly to Dr. Thomas
                                 Hunt, Oxford.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -254,9 +235,7 @@
                                 of Christ Church, to travel through Greece, dated the 1st of Cemāẕī
                                 el-evvel, A. H. 1233 A.D. 1818, March 9.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -276,9 +255,7 @@
                                 <persName xml:lang="ota-Latn-x-lc" role="ctb" key="person_f8742">Frederic Houson
                                     Potter</persName>, Queen's College, Oxford.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -290,8 +267,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent> folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent> folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara">1 column of varying number of lines
@@ -305,9 +281,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -315,9 +289,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_c_1.xml
+++ b/collections/oxford university/MS_Turk_c_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23123">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23123">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -64,7 +67,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775152">Ethé 2060</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=16">Ethé 2060</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Turk_c_7.xml
+++ b/collections/oxford university/MS_Turk_c_7.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23169">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23169">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -393,7 +396,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_d_1.xml
+++ b/collections/oxford university/MS_Turk_d_1.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23321">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_d_1</idno>
@@ -52,9 +53,7 @@
                                 European hand and in Roman characters short Turkish phrases with
                                 Latin paraphrase, remnants of a Turkish exercise-book.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -83,9 +82,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -93,9 +90,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_d_2.xml
+++ b/collections/oxford university/MS_Turk_d_2.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1826">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1826">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,11 +64,11 @@
                               قزوینی</persName>)</persName>. </note>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775156">Brockelmann, Carl. <title>Geschichte der Arabischen Litteratur:
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=20">Brockelmann, Carl. <title>Geschichte der Arabischen Litteratur:
                                  Erster Band</title>. Leiden: Brill. 1943. p. 633: § 14. Kapitel.
                               Geographie und Reisbeschreibungen ¶ 12 (481).</ref>
                         </bibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775156">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=20">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. p. 1177-1178 § (40) 2078</ref></bibl>

--- a/collections/oxford university/MS_Turk_d_3.xml
+++ b/collections/oxford university/MS_Turk_d_3.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23328">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_d_3</idno>
@@ -50,9 +51,7 @@
                                 more information.</note>
                             <note>Probably taken from a school exercise-book.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -81,9 +80,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -91,9 +88,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_d_4.xml
+++ b/collections/oxford university/MS_Turk_d_4.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23322">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_d_4</idno>
@@ -63,9 +64,7 @@
                                 in 1774 or 1775 from the exors. of the Rev. Dr. Thomas Hunt, Regius
                                 Professor of Hebrew.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=68">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -96,28 +95,21 @@
                     </physDesc>
                     <history>
                         <origin>
-                            <origDate calendar="#Gregorian" notBefore="1658-07-29"
-                                notAfter="1659-07-16">between 29 July 1658 and 16 July
+                            <origDate calendar="#Gregorian" notBefore="1658-07-29" notAfter="1659-07-16">between 29 July 1658 and 16 July
                                 1659</origDate>
-                            <origDate calendar="#Hijri-qamari" notBefore="1658-07-29"
-                                notAfter="1659-07-16">1068</origDate>
+                            <origDate calendar="#Hijri-qamari" notBefore="1658-07-29" notAfter="1659-07-16">1068</origDate>
                         </origin>
 
-                        <provenance> Previously owned by <persName role="fmo" key="person_32343452"
-                                >Hunt, Thomas, 1696-1774</persName>, Regius Professor of Hebrew at
+                        <provenance> Previously owned by <persName role="fmo" key="person_32343452">Hunt, Thomas, 1696-1774</persName>, Regius Professor of Hebrew at
                             Oxford. </provenance>
 
-                        <provenance>Entered the Bodleian in <date notBefore="1774" notAfter="1776"
-                                calendar="#Gregorian">1774/1775</date> via the executors of the estate of <persName
-                                role="fmo" key="person_32343452">Hunt, Thomas, 1696-1774</persName>,
+                        <provenance>Entered the Bodleian in <date notBefore="1774" notAfter="1776" calendar="#Gregorian">1774/1775</date> via the executors of the estate of <persName role="fmo" key="person_32343452">Hunt, Thomas, 1696-1774</persName>,
                             Regius Professor of Hebrew or Oxford. </provenance>
                     </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -125,9 +117,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_e_1.xml
+++ b/collections/oxford university/MS_Turk_e_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23112">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23112">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -58,7 +61,7 @@
                             <textLang mainLang="ota">Ottoman Turkish</textLang>
                             <listBibl>
                                 <bibl>
-                                    <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775150">Ethé 2049</ref>
+                                    <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=14">Ethé 2049</ref>
                                 </bibl>
                             </listBibl>
                         </msItem>

--- a/collections/oxford university/MS_Turk_e_2.xml
+++ b/collections/oxford university/MS_Turk_e_2.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1836">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_1836">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,11 +64,11 @@
                      <note>Fragment, beginning only.</note>
                      <listBibl>
                         <bibl>
-                           <ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775156">Brockelmann, Carl. <title>Geschichte der Arabischen Litteratur:
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=20">Brockelmann, Carl. <title>Geschichte der Arabischen Litteratur:
                                  Erster Band</title>. Leiden: Brill. 1943. p. 633: 14. Kapitel.
                               Geographie und Reisbeschreibungen § 12 (481).</ref>
                         </bibl>
-                        <bibl><ref target="https://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775156">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
+                        <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=20">Ethé, Hermann. <title>Catalogue of the Persian, Turkish, Hindûstânî
                                  and Pushtû Manuscripts in the Bodleian Library, Part II: Turkish,
                                  Hindûstânî, Pushtû and Additional Persian Manuscripts</title>.
                               Oxford: Clarendon Press. 1930. p. 1175-1176 § (39) 2077</ref></bibl>

--- a/collections/oxford university/MS_Turk_e_3.xml
+++ b/collections/oxford university/MS_Turk_e_3.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23323">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_e_3</idno>
@@ -60,9 +61,7 @@
                                 11a. On fol. 11b this fragment breaks off. Numerous marginal
                                 additions and glosses.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -95,9 +94,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -105,9 +102,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_e_4.xml
+++ b/collections/oxford university/MS_Turk_e_4.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23324">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_e_4</idno>
@@ -68,9 +69,7 @@
                                 participles, etc.), styled (), begins on fol. 1b middle; ff. 3 and 4
                                 are left blank.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -89,9 +88,7 @@
                             <note>Ff. 5 and 6: beginning of the initial words: كلدى الخ has بر کون
                                 رسول حضرتى صلى الله عليه وسلّم sigl; ff. 7 and 8 left blank.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -115,9 +112,7 @@
                                 Süleymān I (died A. H. 974 A. D. 1566) and Murād IV (died A. H. 1049
                                 A.D. 1640).</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -133,9 +128,7 @@
                                 more information.</note>
                             <note>Fol. 11: a few incomplete letters and notes in Turkish.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -152,9 +145,7 @@
                             <note>Ff. 12 and 13 (the former only half a leaf): fragment of a short
                                 Persian-Turkish glossary, going from the end of ().</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -171,9 +162,7 @@
                             <note>Fol. 14: one leaf torn out of another Persian glossary, with
                                 interlinear Turkish paraphrase in red ink.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=70">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -202,9 +191,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -212,9 +199,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_e_5.xml
+++ b/collections/oxford university/MS_Turk_e_5.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23325">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_e_5</idno>
@@ -79,9 +80,7 @@
                                 1b: سبحان الله ....... امّا بعد معلوم اولسون که حق تعالی كة. کلام
                                 قديمنده جمله مؤمنلره سوره الخ</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=72">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -114,9 +113,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -124,9 +121,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_e_59.xml
+++ b/collections/oxford university/MS_Turk_e_59.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23177">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23177">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -303,7 +306,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_e_6.xml
+++ b/collections/oxford university/MS_Turk_e_6.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23326">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_e_6</idno>
@@ -56,9 +57,7 @@
                                 تعالی از لدن و خلقی براتمدن اول استمشدر که زمانگ آخرنده عزیز اوغلني
                                 الخ.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=65">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -91,9 +90,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -101,9 +98,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Turk_e_60.xml
+++ b/collections/oxford university/MS_Turk_e_60.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23172">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23172">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -289,7 +292,7 @@
 
                         <adminInfo>
                             <recordHist>
-                                <source> Description based on <ref target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source> Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:

--- a/collections/oxford university/MS_Turk_f_2.xml
+++ b/collections/oxford university/MS_Turk_f_2.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_23327">
     <teiHeader>
         <fileDesc>
@@ -16,8 +18,7 @@
                         <street>Broad Street</street>
                         <settlement>Oxford</settlement>
                         <postCode>OX1 3BG</postCode>
-                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections"
-                                >Bodleian Library</ref></addrLine>
+                        <addrLine><ref target="http://www.bodleian.ox.ac.uk/libraries/collections">Bodleian Library</ref></addrLine>
                     </address></pubPlace>
                 <idno>FIHRIST</idno>
                 <idno type="msID">MS_Turk_f_2</idno>
@@ -55,9 +56,7 @@
                                 divination, etc., all originally in the possession of Henr. Charl.
                                 de Hennin (see the preceding copy), 1695.</note>
                             <listBibl>
-                                <bibl><ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <bibl><ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=71">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -69,8 +68,7 @@
                     <physDesc>
                         <objectDesc form="codex">
                             <supportDesc material="chart">
-                                <extent>108 folios <dimensions type="leaf" unit="cm" cert="low"
-                                    /></extent>
+                                <extent>108 folios <dimensions type="leaf" unit="cm" cert="low"/></extent>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" n="mistara">1 column of varying number of lines
@@ -84,9 +82,7 @@
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>Description based on <ref
-                                        target="https://menadoc.bibliothek.uni-halle.de/publicdomain/content/titleinfo/775134"
-                                        >Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
+                                <source>Description based on <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475">Ethé, Hermann. <title>Catalogue of the Persian, Turkish,
                                             Hindûstânî and Pushtû Manuscripts in the Bodleian
                                             Library, Part II: Turkish, Hindûstânî, Pushtû and
                                             Additional Persian Manuscripts</title>. Oxford:
@@ -94,9 +90,7 @@
                             </recordHist>
                             <availability status="restricted">
                                 <p>Entry to read in the Library is permitted only on presentation of
-                                    a valid reader's card (for admissions procedures contact <ref
-                                        target="http://www.bodleian.ox.ac.uk/services/admissions/"
-                                        >Bodleian Admissions</ref>). Contact
+                                    a valid reader's card (for admissions procedures contact <ref target="http://www.bodleian.ox.ac.uk/services/admissions/">Bodleian Admissions</ref>). Contact
                                         <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
                                     for further information on the availability of this
                                     manuscript.</p>

--- a/collections/oxford university/MS_Zend_e_1.xml
+++ b/collections/oxford university/MS_Zend_e_1.xml
@@ -1,4 +1,7 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22942">
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_22942">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -52,7 +55,7 @@
                         Sanskrit.</textLang>
                      <listBibl>
                         <bibl>
-                           <ref target="http://menadoc.bibliothek.uni-halle.de/ssg/content/pageview/775237">Ethé 2399</ref>
+                           <ref target="https://babel.hathitrust.org/cgi/pt?id=uiug.30112084973475&amp;seq=101">Ethé 2399</ref>
                         </bibl>
                         <bibl>WK 1611</bibl>
                      </listBibl>


### PR DESCRIPTION
This PR replaces the menadoc links to Ethé to the Hathitrust version.

It also, @kontovasBodleian, attempts to marry up the records you created to the correct Hathitrust page. Have a gander and tell me if I did badly. 

(I know you know this but if you're looking at the XML, remember to either preview it or get rid of the "amp;" escaping the `&`, otherwise the URLs won't work. They'll work on the site itself.)